### PR TITLE
add forChild()

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,21 @@ If you use a [`SharedModule`](https://angular.io/docs/ts/latest/guide/ngmodule.h
 export class SharedModule { }
 ```
 
-> Note: Never call a `forRoot` static method in the `SharedModule`. You will end up with multiple different instances of a service in your injector tree.
+> Note: Never call a `forRoot` static method in the `SharedModule`, use `forChild` instead. You will end up with multiple different instances of a service in your injector tree.
+
+```ts
+@NgModule({
+    exports: [
+        CommonModule,
+        TranslateModule.forChild({
+            provide: TranslateLoader,
+            useFactory: (http: Http) => new TranslateStaticLoader(http, '/assets/i18n/SharedModule', '.json'),
+            deps: [Http]
+        })
+    ]
+})
+export class SharedModule { }
+```
 
 ##### Configuration
 
@@ -250,7 +264,7 @@ To render them, simply use the `innerHTML` attribute with the pipe on any elemen
 	  // do something
 	});
     ```
-    
+
 #### Methods:
 
 - `setDefaultLang(lang: string)`: Sets the default language to use as a fallback

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import {NgModule, ModuleWithProviders} from "@angular/core";
 import {Http, HttpModule} from "@angular/http";
 import {TranslatePipe} from "./src/translate.pipe";
 import {TranslateParser, DefaultTranslateParser} from "./src/translate.parser";
-import {TranslateService, TranslateLoader, TranslateStaticLoader} from "./src/translate.service";
+import {TranslateService, TranslateLoader, TranslateStaticLoader, ModuleLoader} from "./src/translate.service";
 import {TranslateDirective} from "./src/translate.directive";
 
 export * from "./src/translate.pipe";
@@ -32,11 +32,30 @@ export class TranslateModule {
         useFactory: translateLoaderFactory,
         deps: [Http]
     }): ModuleWithProviders {
+        // var id = 'root';
         return {
             ngModule: TranslateModule,
             providers: [
                 providedLoader,
                 TranslateService,
+                ModuleLoader,
+                { provide: TranslateParser, useClass: DefaultTranslateParser }
+            ]
+        };
+    }
+    static forChild(providedLoader: any = {
+        provide: TranslateLoader,
+        useFactory: translateLoaderFactory,
+        deps: [Http]
+    }): ModuleWithProviders {
+        console.log('for child');
+
+        // var id = 'child';
+        return {
+            ngModule: TranslateModule,
+            providers: [
+                providedLoader,
+                ModuleLoader,
                 { provide: TranslateParser, useClass: DefaultTranslateParser }
             ]
         };

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,7 @@ export class TranslateModule {
             providers: [
                 providedLoader,
                 TranslateService,
-                ModuleLoader,
+                { provide: ModuleLoader, useValue: {uid: 'root'} },
                 { provide: TranslateParser, useClass: DefaultTranslateParser }
             ]
         };

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from "@angular/core";
+import {NgModule, ModuleWithProviders, Injector} from "@angular/core";
 import {Http, HttpModule} from "@angular/http";
 import {TranslatePipe} from "./src/translate.pipe";
 import {TranslateParser, DefaultTranslateParser} from "./src/translate.parser";
@@ -27,6 +27,12 @@ export function translateLoaderFactory(http: Http) {
     ]
 })
 export class TranslateModule {
+
+    static INJECTOR: Injector;
+
+    constructor(Injector: Injector) {
+      TranslateModule.INJECTOR = Injector;
+    }
     static forRoot(providedLoader: any = {
         provide: TranslateLoader,
         useFactory: translateLoaderFactory,
@@ -48,15 +54,13 @@ export class TranslateModule {
         useFactory: translateLoaderFactory,
         deps: [Http]
     }): ModuleWithProviders {
-        console.log('for child');
-
-        // var id = 'child';
+        let service: TranslateService = TranslateModule.INJECTOR.get(TranslateService);
+        let moduleLoader = new ModuleLoader(service, TranslateModule.INJECTOR, providedLoader);
         return {
             ngModule: TranslateModule,
             providers: [
                 providedLoader,
-                ModuleLoader,
-                { provide: TranslateParser, useClass: DefaultTranslateParser }
+                { provide: ModuleLoader, useValue: moduleLoader }
             ]
         };
     }

--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ export class TranslateModule {
                 providedLoader,
                 TranslateService,
                 ModuleLoader,
-                { provide: ModuleIdentifier, useValue: {uid: 'root'} },
+                { provide: ModuleIdentifier, useValue: {id: 'root'} },
                 { provide: TranslateParser, useClass: DefaultTranslateParser }
             ]
         };
@@ -52,18 +52,13 @@ export class TranslateModule {
         useFactory: translateLoaderFactory,
         deps: [Http]
     }): ModuleWithProviders {
-        let uid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
-          function(c: string) {
-              var r = Math.floor(Math.random() * 16),
-                  v = c === 'x' ? r : (r % 4 + 4);
-              return v.toString(16);
-          }).toUpperCase();
+        let id = Math.random().toString(36);
         return {
             ngModule: TranslateModule,
             providers: [
                 providedLoader,
                 ModuleLoader,
-                { provide: ModuleIdentifier, useValue: {uid: uid} }
+                { provide: ModuleIdentifier, useValue: {id: id} }
             ]
         };
     }

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
-import {NgModule, ModuleWithProviders, Injector} from "@angular/core";
+import {NgModule, ModuleWithProviders} from "@angular/core";
 import {Http, HttpModule} from "@angular/http";
 import {TranslatePipe} from "./src/translate.pipe";
 import {TranslateParser, DefaultTranslateParser} from "./src/translate.parser";
-import {TranslateService, TranslateLoader, TranslateStaticLoader, ModuleLoader} from "./src/translate.service";
+import {TranslateService, TranslateLoader, TranslateStaticLoader, ModuleLoader, ModuleIdentifier} from "./src/translate.service";
 import {TranslateDirective} from "./src/translate.directive";
 
 export * from "./src/translate.pipe";
@@ -27,12 +27,6 @@ export function translateLoaderFactory(http: Http) {
     ]
 })
 export class TranslateModule {
-
-    static INJECTOR: Injector;
-
-    constructor(Injector: Injector) {
-      TranslateModule.INJECTOR = Injector;
-    }
     static forRoot(providedLoader: any = {
         provide: TranslateLoader,
         useFactory: translateLoaderFactory,
@@ -44,7 +38,7 @@ export class TranslateModule {
             providers: [
                 providedLoader,
                 TranslateService,
-                { provide: ModuleLoader, useValue: {uid: 'root'} },
+                { provide: ModuleIdentifier, useValue: {uid: 'root'} },
                 { provide: TranslateParser, useClass: DefaultTranslateParser }
             ]
         };
@@ -54,13 +48,18 @@ export class TranslateModule {
         useFactory: translateLoaderFactory,
         deps: [Http]
     }): ModuleWithProviders {
-        let service: TranslateService = TranslateModule.INJECTOR.get(TranslateService);
-        let moduleLoader = new ModuleLoader(service, TranslateModule.INJECTOR, providedLoader);
+        let uid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
+          function(c: string) {
+              var r = Math.floor(Math.random() * 16),
+                  v = c === 'x' ? r : (r % 4 + 4);
+              return v.toString(16);
+          }).toUpperCase();
         return {
             ngModule: TranslateModule,
             providers: [
                 providedLoader,
-                { provide: ModuleLoader, useValue: moduleLoader }
+                ModuleLoader,
+                { provide: ModuleIdentifier, useValue: {uid: uid} }
             ]
         };
     }

--- a/index.ts
+++ b/index.ts
@@ -27,17 +27,21 @@ export function translateLoaderFactory(http: Http) {
     ]
 })
 export class TranslateModule {
+
+    constructor(loader: ModuleLoader) {
+      loader.init();
+    }
     static forRoot(providedLoader: any = {
         provide: TranslateLoader,
         useFactory: translateLoaderFactory,
         deps: [Http]
     }): ModuleWithProviders {
-        // var id = 'root';
         return {
             ngModule: TranslateModule,
             providers: [
                 providedLoader,
                 TranslateService,
+                ModuleLoader,
                 { provide: ModuleIdentifier, useValue: {uid: 'root'} },
                 { provide: TranslateParser, useClass: DefaultTranslateParser }
             ]

--- a/src/translate.directive.ts
+++ b/src/translate.directive.ts
@@ -111,7 +111,8 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
                     onTranslation(res);
                 }
             } else {
-                this.translateService.get(this.ModuleLoader.uid, key, interpolateParams).subscribe(onTranslation);
+                this.translateService.setCurrentModuleId(this.ModuleLoader.uid);
+                this.translateService.get(key, interpolateParams).subscribe(onTranslation);
             }
         }
     }

--- a/src/translate.directive.ts
+++ b/src/translate.directive.ts
@@ -111,8 +111,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
                     onTranslation(res);
                 }
             } else {
-                this.translateService.setCurrentModuleId(this.ModuleLoader.uid);
-                this.translateService.get(key, interpolateParams).subscribe(onTranslation);
+                this.translateService.get(key, interpolateParams, this.ModuleLoader.uid).subscribe(onTranslation);
             }
         }
     }

--- a/src/translate.directive.ts
+++ b/src/translate.directive.ts
@@ -4,7 +4,7 @@ import {isDefined} from './util';
 import {TranslateService, LangChangeEvent} from './translate.service';
 import {TranslationChangeEvent} from "./translate.service";
 import {DefaultLangChangeEvent} from "./translate.service";
-import {ModuleLoader} from "./translate.service";
+import {ModuleIdentifier} from "./translate.service";
 
 @Directive({
     selector: '[translate],[ng2-translate]'
@@ -15,6 +15,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
     onLangChangeSub: Subscription;
     onDefaultLangChangeSub: Subscription;
     onTranslationChangeSub: Subscription;
+    moduleId: string = 'root';
 
     @Input() set translate(key: string) {
         if(key) {
@@ -25,7 +26,10 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
 
     @Input() translateParams: any;
 
-    constructor(private translateService: TranslateService, private element: ElementRef, private ModuleLoader: ModuleLoader) {
+    constructor(private translateService: TranslateService, private element: ElementRef, private ModuleId: ModuleIdentifier) {
+        if (this.ModuleId && this.ModuleId.uid) {
+          this.moduleId = this.ModuleId.uid;
+        }
         // subscribe to onTranslationChange event, in case the translations of the current lang change
         if(!this.onTranslationChangeSub) {
             this.onTranslationChangeSub = this.translateService.onTranslationChange.subscribe((event: TranslationChangeEvent) => {
@@ -111,7 +115,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
                     onTranslation(res);
                 }
             } else {
-                this.translateService.get(key, interpolateParams, this.ModuleLoader.uid).subscribe(onTranslation);
+                this.translateService.get(key, interpolateParams, this.moduleId).subscribe(onTranslation);
             }
         }
     }

--- a/src/translate.directive.ts
+++ b/src/translate.directive.ts
@@ -4,6 +4,7 @@ import {isDefined} from './util';
 import {TranslateService, LangChangeEvent} from './translate.service';
 import {TranslationChangeEvent} from "./translate.service";
 import {DefaultLangChangeEvent} from "./translate.service";
+import {ModuleLoader} from "./translate.service";
 
 @Directive({
     selector: '[translate],[ng2-translate]'
@@ -24,7 +25,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
 
     @Input() translateParams: any;
 
-    constructor(private translateService: TranslateService, private element: ElementRef) {
+    constructor(private translateService: TranslateService, private element: ElementRef, private ModuleLoader: ModuleLoader) {
         // subscribe to onTranslationChange event, in case the translations of the current lang change
         if(!this.onTranslationChangeSub) {
             this.onTranslationChangeSub = this.translateService.onTranslationChange.subscribe((event: TranslationChangeEvent) => {
@@ -110,7 +111,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
                     onTranslation(res);
                 }
             } else {
-                this.translateService.get(key, interpolateParams).subscribe(onTranslation);
+                this.translateService.get(this.ModuleLoader.uid, key, interpolateParams).subscribe(onTranslation);
             }
         }
     }

--- a/src/translate.directive.ts
+++ b/src/translate.directive.ts
@@ -27,8 +27,8 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
     @Input() translateParams: any;
 
     constructor(private translateService: TranslateService, private element: ElementRef, private ModuleId: ModuleIdentifier) {
-        if (this.ModuleId && this.ModuleId.uid) {
-          this.moduleId = this.ModuleId.uid;
+        if (this.ModuleId && this.ModuleId.id) {
+          this.moduleId = this.ModuleId.id;
         }
         // subscribe to onTranslationChange event, in case the translations of the current lang change
         if(!this.onTranslationChangeSub) {

--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -1,5 +1,5 @@
 import {PipeTransform, Pipe, Injectable, EventEmitter, OnDestroy, ChangeDetectorRef} from '@angular/core';
-import {TranslateService, LangChangeEvent, TranslationChangeEvent, DefaultLangChangeEvent, ModuleLoader} from './translate.service';
+import {TranslateService, LangChangeEvent, TranslationChangeEvent, DefaultLangChangeEvent, ModuleIdentifier} from './translate.service';
 import {equals, isDefined} from './util';
 
 @Injectable()
@@ -14,9 +14,13 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     onTranslationChange: EventEmitter<TranslationChangeEvent>;
     onLangChange: EventEmitter<LangChangeEvent>;
     onDefaultLangChange: EventEmitter<DefaultLangChangeEvent>;
+    moduleId: string = 'root';
 
-    constructor(private translate: TranslateService, private _ref: ChangeDetectorRef, private ModuleLoader: ModuleLoader) {
-      console.log('pipe constructor', this.ModuleLoader);
+    constructor(private translate: TranslateService, private _ref: ChangeDetectorRef, private ModuleId: ModuleIdentifier) {
+      if (this.ModuleId && this.ModuleId.uid) {
+        this.moduleId = this.ModuleId.uid;
+      }
+      console.log('pipe constructor', this.moduleId);
     }
 
     updateValue(key: string, interpolateParams?: Object, translations?: any): void {
@@ -33,7 +37,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
                 onTranslation(res);
             }
         }
-        this.translate.get(key, interpolateParams, this.ModuleLoader.uid).subscribe(onTranslation);
+        this.translate.get(key, interpolateParams, this.moduleId).subscribe(onTranslation);
     }
 
     transform(query: string, ...args: any[]): any {

--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -17,8 +17,8 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     moduleId: string = 'root';
 
     constructor(private translate: TranslateService, private _ref: ChangeDetectorRef, private ModuleId: ModuleIdentifier) {
-      if (this.ModuleId && this.ModuleId.uid) {
-        this.moduleId = this.ModuleId.uid;
+      if (this.ModuleId && this.ModuleId.id) {
+        this.moduleId = this.ModuleId.id;
       }
     }
 

--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -33,7 +33,8 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
                 onTranslation(res);
             }
         }
-        this.translate.get(this.ModuleLoader.uid, key, interpolateParams).subscribe(onTranslation);
+        this.translate.setCurrentModuleId(this.ModuleLoader.uid);
+        this.translate.get(key, interpolateParams).subscribe(onTranslation);
     }
 
     transform(query: string, ...args: any[]): any {

--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -1,5 +1,5 @@
 import {PipeTransform, Pipe, Injectable, EventEmitter, OnDestroy, ChangeDetectorRef} from '@angular/core';
-import {TranslateService, LangChangeEvent, TranslationChangeEvent, DefaultLangChangeEvent} from './translate.service';
+import {TranslateService, LangChangeEvent, TranslationChangeEvent, DefaultLangChangeEvent, ModuleLoader} from './translate.service';
 import {equals, isDefined} from './util';
 
 @Injectable()
@@ -15,7 +15,8 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     onLangChange: EventEmitter<LangChangeEvent>;
     onDefaultLangChange: EventEmitter<DefaultLangChangeEvent>;
 
-    constructor(private translate: TranslateService, private _ref: ChangeDetectorRef) {
+    constructor(private translate: TranslateService, private _ref: ChangeDetectorRef, private ModuleLoader: ModuleLoader) {
+      console.log('pipe constructor', this.ModuleLoader);
     }
 
     updateValue(key: string, interpolateParams?: Object, translations?: any): void {
@@ -32,7 +33,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
                 onTranslation(res);
             }
         }
-        this.translate.get(key, interpolateParams).subscribe(onTranslation);
+        this.translate.get(this.ModuleLoader.uid, key, interpolateParams).subscribe(onTranslation);
     }
 
     transform(query: string, ...args: any[]): any {

--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -20,7 +20,6 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
       if (this.ModuleId && this.ModuleId.uid) {
         this.moduleId = this.ModuleId.uid;
       }
-      console.log('pipe constructor', this.moduleId);
     }
 
     updateValue(key: string, interpolateParams?: Object, translations?: any): void {

--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -33,8 +33,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
                 onTranslation(res);
             }
         }
-        this.translate.setCurrentModuleId(this.ModuleLoader.uid);
-        this.translate.get(key, interpolateParams).subscribe(onTranslation);
+        this.translate.get(key, interpolateParams, this.ModuleLoader.uid).subscribe(onTranslation);
     }
 
     transform(query: string, ...args: any[]): any {

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, EventEmitter, Optional, Injector} from "@angular/core";
+import {Injectable, EventEmitter, Optional} from "@angular/core";
 import {Http, Response} from "@angular/http";
 import {Observable} from "rxjs/Observable";
 import {Observer} from "rxjs/Observer";
@@ -148,7 +148,7 @@ export class TranslateService {
     }
 
     public addLoader(currentModuleId: string, loader: TranslateLoader): void {
-        if (this.loaders['root'] === loader) {
+        if (this.loaders[currentModuleId]) {
           return;
         }
         this.setCurrentModuleId(currentModuleId);
@@ -550,20 +550,13 @@ export class TranslateService {
     }
 }
 
+export class ModuleIdentifier {
+    public uid: string = '';
+}
+
 @Injectable()
 export class ModuleLoader {
-    public uid: string = '';
-
-    constructor(translateService: TranslateService, public Injector: Injector, providedLoader: any) {
-      let providerLoader = providedLoader.provide || providedLoader;
-      let loader = this.Injector.get(providerLoader);
-      this.uid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
-          function(c: string) {
-              var r = Math.floor(Math.random() * 16), 
-                  v = c === 'x' ? r : (r % 4 + 4);
-              return v.toString(16);          
-          }).toUpperCase();
-      translateService.addLoader(this.uid, loader);
-      console.log('ModuleLoader constructor', this.uid);
+    constructor(public identifier: ModuleIdentifier, public translateService: TranslateService, public loader: TranslateLoader) {
+        translateService.addLoader(this.identifier.uid, loader);
     }
 }

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -124,6 +124,7 @@ export class TranslateService {
 
     private defaultLang: string;
     public modules: any = {};
+    public currentLoader: TranslateLoader;
     private currentModule: ModuleLoader;
 
     /**
@@ -149,6 +150,7 @@ export class TranslateService {
 
     private setCurrentModule(currentModule: ModuleLoader): void {
         this.currentModule = currentModule;
+        this.currentLoader = currentModule.loader;
     }
 
     private getCurrentModule(): ModuleLoader {

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -140,8 +140,8 @@ export class TranslateService {
 
     public addModule(module: ModuleLoader): void {
         this.setCurrentModule(module);
-        if (!this.modules[module.uid]) {
-            this.modules[module.uid] = module;
+        if (!this.modules[module.id]) {
+            this.modules[module.id] = module;
         }
         if (this.currentLang) {
           module.getTranslation(this.currentLang);
@@ -514,19 +514,19 @@ export class TranslateService {
 }
 
 export class ModuleIdentifier {
-    public uid: string = '';
+    public id: string = '';
 }
 
 @Injectable()
 export class ModuleLoader {
-    public uid: string;
+    public id: string;
     public translations: any = {};
     private langs: Array<string> = [];
     public pending: Observable<any>;
     private onTranslationChange: EventEmitter<TranslationChangeEvent> = new EventEmitter<TranslationChangeEvent>();
 
     constructor(identifier: ModuleIdentifier, public translateService: TranslateService, public loader: TranslateLoader) {
-        this.uid = identifier.uid;
+        this.id = identifier.id;
     }
     public init(): void {
         this.translateService.addModule(this);

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, EventEmitter, Optional} from "@angular/core";
+import {Injectable, EventEmitter, Optional, Injector} from "@angular/core";
 import {Http, Response} from "@angular/http";
 import {Observable} from "rxjs/Observable";
 import {Observer} from "rxjs/Observer";
@@ -554,14 +554,16 @@ export class TranslateService {
 export class ModuleLoader {
     public uid: string = '';
 
-    constructor(public currentLoader: TranslateLoader, public TranslateService: TranslateService) {
+    constructor(translateService: TranslateService, public Injector: Injector, providedLoader: any) {
+      let providerLoader = providedLoader.provide || providedLoader;
+      let loader = this.Injector.get(providerLoader);
       this.uid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
           function(c: string) {
               var r = Math.floor(Math.random() * 16), 
                   v = c === 'x' ? r : (r % 4 + 4);
               return v.toString(16);          
           }).toUpperCase();
-      this.TranslateService.addLoader(this.uid, this.currentLoader);
+      translateService.addLoader(this.uid, loader);
       console.log('ModuleLoader constructor', this.uid);
     }
 }

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -331,14 +331,14 @@ export class TranslateService {
      * @param interpolateParams
      * @returns {any}
      */
-    public getParsedResult(moduleId: string, translations: any, key: any, interpolateParams?: Object): any {
+    public getParsedResult(translations: any, key: any, interpolateParams?: Object): any {
         let res: string|Observable<string>;
 
         if(key instanceof Array) {
             let result: any = {},
                 observables: boolean = false;
             for(let k of key) {
-                result[k] = this.getParsedResult(moduleId, translations, k, interpolateParams);
+                result[k] = this.getParsedResult(translations, k, interpolateParams);
                 if(typeof result[k].subscribe === "function") {
                     observables = true;
                 }

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -142,6 +142,9 @@ export class TranslateService {
         if (!this.modules[module.uid]) {
             this.modules[module.uid] = module;
         }
+        if (this.currentLang) {
+          module.getTranslation(this.currentLang);
+        }
     }
 
     private setCurrentModule(currentModule: ModuleLoader): void {

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -389,7 +389,7 @@ export class TranslateService {
      * @param interpolateParams
      * @returns {any} the translated key, or an object of translated keys
      */
-    public get(key: string|Array<string>, interpolateParams?: Object): Observable<string|any> {
+    public get(key: string|Array<string>, interpolateParams?: Object, moduleId: string = 'root'): Observable<string|any> {
         if(!isDefined(key) || !key.length) {
             throw new Error(`Parameter "key" required`);
         }
@@ -405,7 +405,7 @@ export class TranslateService {
                 };
                 this.pending.subscribe((res: any) => {
                   console.log('res', res);
-                    res = this.getParsedResult(res[this.currentModuleId], key, interpolateParams);
+                    res = this.getParsedResult(res[moduleId], key, interpolateParams);
                     if(typeof res.subscribe === "function") {
                         res.subscribe(onComplete, onError);
                     } else {
@@ -414,7 +414,7 @@ export class TranslateService {
                 }, onError);
             });
         } else {
-            let res = this.getParsedResult(this.translations[this.currentModuleId][this.currentLang], key, interpolateParams);
+            let res = this.getParsedResult(this.translations[moduleId][this.currentLang], key, interpolateParams);
             if(typeof res.subscribe === "function") {
                 return res;
             } else {

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, EventEmitter, Optional} from "@angular/core";
+import {Injectable, EventEmitter, Optional, Injector} from "@angular/core";
 import {Http, Response} from "@angular/http";
 import {Observable} from "rxjs/Observable";
 import {Observer} from "rxjs/Observer";
@@ -138,6 +138,7 @@ export class TranslateService {
     constructor(
         public parser: TranslateParser,
         public rootLoader: TranslateLoader,
+        public injector: Injector,
         @Optional() private missingTranslationHandler: MissingTranslationHandler
     ) {
       console.log('constructor translate service');
@@ -393,6 +394,11 @@ export class TranslateService {
         if(!isDefined(key) || !key.length) {
             throw new Error(`Parameter "key" required`);
         }
+        // inject loader
+        if (!this.loaders[moduleId]) {
+          this.injector.get(ModuleLoader);
+          this.retrieveTranslations(this.currentLang);
+        }
         // check if we are loading a new translation to use
         if(this.pending) {
             return Observable.create((observer: Observer<string>) => {
@@ -557,6 +563,7 @@ export class ModuleIdentifier {
 @Injectable()
 export class ModuleLoader {
     constructor(public identifier: ModuleIdentifier, public translateService: TranslateService, public loader: TranslateLoader) {
+        console.log('ModuleLoader ',this.identifier.uid);
         translateService.addLoader(this.identifier.uid, loader);
     }
 }

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, EventEmitter, Optional, Injector} from "@angular/core";
+import {Injectable, EventEmitter, Optional} from "@angular/core";
 import {Http, Response} from "@angular/http";
 import {Observable} from "rxjs/Observable";
 import {Observer} from "rxjs/Observer";
@@ -138,7 +138,6 @@ export class TranslateService {
     constructor(
         public parser: TranslateParser,
         public rootLoader: TranslateLoader,
-        public injector: Injector,
         @Optional() private missingTranslationHandler: MissingTranslationHandler
     ) {
       console.log('constructor translate service');
@@ -155,6 +154,7 @@ export class TranslateService {
         this.setCurrentModuleId(currentModuleId);
         this.loaders[currentModuleId] = loader;
         this.translations[currentModuleId] = {};
+        this.retrieveTranslations(this.currentLang);
     }
 
     public setCurrentModuleId(currentModuleId: string): void {
@@ -394,11 +394,6 @@ export class TranslateService {
         if(!isDefined(key) || !key.length) {
             throw new Error(`Parameter "key" required`);
         }
-        // inject loader
-        if (!this.loaders[moduleId]) {
-          this.injector.get(ModuleLoader);
-          this.retrieveTranslations(this.currentLang);
-        }
         // check if we are loading a new translation to use
         if(this.pending) {
             return Observable.create((observer: Observer<string>) => {
@@ -564,6 +559,8 @@ export class ModuleIdentifier {
 export class ModuleLoader {
     constructor(public identifier: ModuleIdentifier, public translateService: TranslateService, public loader: TranslateLoader) {
         console.log('ModuleLoader ',this.identifier.uid);
-        translateService.addLoader(this.identifier.uid, loader);
+    }
+    public init(): void {
+        this.translateService.addLoader(this.identifier.uid, this.loader);
     }
 }

--- a/tests/translate.pipe.spec.ts
+++ b/tests/translate.pipe.spec.ts
@@ -1,4 +1,4 @@
-import {TranslatePipe} from '../src/translate.pipe';
+/*import {TranslatePipe} from '../src/translate.pipe';
 import {TranslateService, TranslateModule} from "./../ng2-translate";
 import {ResponseOptions, Response, XHRBackend, HttpModule} from "@angular/http";
 import {
@@ -159,7 +159,7 @@ describe('TranslatePipe', () => {
 
     it("should throw if you don't give an object parameter", () => {
         translate.setTranslation('en', {"TEST": "This is a test {{param}}"});
-        translate.use('en');
+        translate.use('enTranslatePipe');
         let param = 'param: "with param"';
 
         expect(() => {
@@ -288,3 +288,4 @@ describe('TranslatePipe', () => {
         });
     });
 });
+*/

--- a/tests/translate.pipe.spec.ts
+++ b/tests/translate.pipe.spec.ts
@@ -1,4 +1,4 @@
-/*import {TranslatePipe} from '../src/translate.pipe';
+import {TranslatePipe} from '../src/translate.pipe';
 import {TranslateService, TranslateModule} from "./../ng2-translate";
 import {ResponseOptions, Response, XHRBackend, HttpModule} from "@angular/http";
 import {
@@ -62,7 +62,7 @@ describe('TranslatePipe', () => {
         backend.connections.subscribe((c: MockConnection) => connection = c);
 
         ref = new FakeChangeDetectorRef();
-        translatePipe = new TranslatePipe(translate, ref);
+        translatePipe = new TranslatePipe(translate, ref, {uid: 'root'});
     });
 
     afterEach(() => {
@@ -288,4 +288,3 @@ describe('TranslatePipe', () => {
         });
     });
 });
-*/

--- a/tests/translate.pipe.spec.ts
+++ b/tests/translate.pipe.spec.ts
@@ -62,7 +62,7 @@ describe('TranslatePipe', () => {
         backend.connections.subscribe((c: MockConnection) => connection = c);
 
         ref = new FakeChangeDetectorRef();
-        translatePipe = new TranslatePipe(translate, ref, {uid: 'root'});
+        translatePipe = new TranslatePipe(translate, ref, {id: 'root'});
     });
 
     afterEach(() => {

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -551,8 +551,8 @@ describe('TranslateLoader', () => {
         prepare(injector);
 
         expect(translate).toBeDefined();
-        expect(translate.modules.root.loader).toBeDefined();
-        expect(translate.modules.root.loader instanceof TranslateStaticLoader).toBeTruthy();
+        expect(translate.currentLoader).toBeDefined();
+        expect(translate.currentLoader instanceof TranslateStaticLoader).toBeTruthy();
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use('en');
@@ -582,8 +582,8 @@ describe('TranslateLoader', () => {
         prepare(injector);
 
         expect(translate).toBeDefined();
-        expect(translate.modules.root.loader).toBeDefined();
-        expect(translate.modules.root.loader instanceof CustomLoader).toBeTruthy();
+        expect(translate.currentLoader).toBeDefined();
+        expect(translate.currentLoader instanceof CustomLoader).toBeTruthy();
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use('en');

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -1,4 +1,4 @@
-import {Injector} from "@angular/core";
+/*import {Injector} from "@angular/core";
 import {ResponseOptions, Response, XHRBackend, HttpModule} from "@angular/http";
 import {MockBackend, MockConnection} from "@angular/http/testing";
 import {
@@ -595,3 +595,4 @@ describe('TranslateLoader', () => {
     });
 
 });
+*/

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -1,4 +1,4 @@
-/*import {Injector} from "@angular/core";
+import {Injector} from "@angular/core";
 import {ResponseOptions, Response, XHRBackend, HttpModule} from "@angular/http";
 import {MockBackend, MockConnection} from "@angular/http/testing";
 import {
@@ -551,8 +551,8 @@ describe('TranslateLoader', () => {
         prepare(injector);
 
         expect(translate).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof TranslateStaticLoader).toBeTruthy();
+        expect(translate.modules.root.loader).toBeDefined();
+        expect(translate.modules.root.loader instanceof TranslateStaticLoader).toBeTruthy();
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use('en');
@@ -582,8 +582,8 @@ describe('TranslateLoader', () => {
         prepare(injector);
 
         expect(translate).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof CustomLoader).toBeTruthy();
+        expect(translate.modules.root.loader).toBeDefined();
+        expect(translate.modules.root.loader instanceof CustomLoader).toBeTruthy();
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use('en');
@@ -595,4 +595,3 @@ describe('TranslateLoader', () => {
     });
 
 });
-*/


### PR DESCRIPTION
TranslateModule can be imported multiple times: once per lazily-loaded bundle.
That is why there are two ways to create the module: TranslateModule.forRoot and TranslateModule.forChild.

forRoot creates a module that contains all the directives, the given loader, and the TranslateService service itself.

forChild creates a module that does not include the TranslateService service but a new given loader for the module (useful for splitting translation files).

When registered at the root, the module should be used as follows

```
@NgModule({
  imports: [TranslateModule.forRoot(Loader)]
})
class MyNgModule {}
```

For submodules and lazy loaded submodules the module should be used as follows:

```
@NgModule({
  imports: [TranslateModule.forChild(Loader)]
})
class MyNgModule {}
```
