### PR TITLE
fix: do not return object as translation

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -333,9 +333,10 @@ export class TranslateService {
                 params.interpolateParams = interpolateParams;
             }
             res = this.missingTranslationHandler.handle(params);
+            return typeof res !== "undefined" ? res : key;
         }
 
-        return typeof res !== "undefined" ? res : key;
+        return typeof res === "string" ? res : key;
     }
 
     /**

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -117,6 +117,17 @@ describe('TranslateService', () => {
         mockBackendResponse(connection, '{}');
     });
 
+    it('should return they key when getting an object as the translation if supplying half of a key', () => {
+        translate.use('en');
+
+        translate.get('TEST').subscribe((res: string) => {
+            expect(res).not.toEqual({"SUBTEST": "Dit is een test"});
+            expect(res).toEqual('TEST');
+        });
+
+        mockBackendResponse(connection, '{"TEST": {"SUBTEST": "Dit is een test"}}');
+    });
+
     it("should return the key when you haven't defined any translation", () => {
         translate.get('TEST').subscribe((res: string) => {
             expect(res).toEqual('TEST');


### PR DESCRIPTION
Previous to this fix, if passing in a partial key as a translation, it would return the child object instead of handling it as a missing translation and returning the key.

**Previously:**

Translation file: `{"admin": {"list": "Admin List"}}`
`{{'admin' | translate}}` displayed [Object object] because it was getting `{"list": "Admin List"}`

**After Fix:**
Translation file: `{"admin": {"list": "Admin List"}}`
`{{'admin' | translate}}` will display 'admin' or go through the custom missing translation handler.