### PR TITLE
fix(build): cross platform cp

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/jasmine": "2.5.41",
     "@types/node": "7.0.4",
     "awesome-typescript-loader": "3.0.0-beta.18",
+    "cash-cp": "0.2.0",
     "codelyzer": "2.0.0-beta.4",
     "commitizen": "2.9.5",
     "core-js": "2.4.1",


### PR DESCRIPTION
Fix https://github.com/ngx-translate/core/issues/416

* Install npm package 'cash-cp' as devDependency