### PR TITLE
docs(README): fix travis & npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ng2-translate [![Build Status](https://travis-ci.org/ocombe/ng2-translate.svg?branch=master)](https://travis-ci.org/ocombe/ng2-translate) [![npm version](https://img.shields.io/npm/v/ng2-translate.svg)](https://www.npmjs.com/package/ng2-translate)
+# ng2-translate [![Build Status](https://travis-ci.org/ngx-translate/core.svg?branch=master)](https://travis-ci.org/ngx-translate/core) [![npm version](https://img.shields.io/npm/v/@ngx-translate/core.svg)](https://www.npmjs.com/package/@ngx-translate/core)
 
 An implementation of angular translate for Angular 2.
 


### PR DESCRIPTION
Fixes the travis and npm badges. The npm badge image link should be correct, however it didn't load at the moment because there seems to be issues with the shields.io service. At least that's what Cloudflare told me :smile:.