### PR TITLE
chore(webpack): fit to webpack v2 best practices

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,10 @@ module.exports = {
             exclude: [helpers.root('node_modules')]
         }, {
             test: /\.ts$/,
-            loader: 'awesome-typescript-loader?declaration=false',
+            loader: 'awesome-typescript-loader',
+            options: {
+                declaration: false
+            },
             exclude: [/\.e2e\.ts$/]
         }]
     },


### PR DESCRIPTION
According to [Webpack 2 best practices](https://webpack.js.org/guides/migrating/) rather than using the `?options` the more explicit `options` prop should be used.

(Really just a minor thing :wink:)