### PR TITLE
docs(README): Fix asset path in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you want to configure a custom `TranslateLoader` while using [AoT compilation
 
 ```ts
 export function createTranslateLoader(http: Http) {
-    return new TranslateHttpLoader(http, './assets/i18n', '.json');
+    return new TranslateHttpLoader(http, './assets/i18n/', '.json');
 }
 
 @NgModule({


### PR DESCRIPTION
Noticed that this changes since `ng2-translate`. We need a trailing `/` in order for that to work.