### PR TITLE
fix(TranslateService): only make one request per lang

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -47,6 +47,7 @@ export class TranslateService {
     private _currentLang: string;
     private _langs: Array<string> = [];
     private _translations: any = {};
+    private _translationRequests: any  = {};
 
     /**
      * An EventEmitter to listen to translation change events
@@ -230,7 +231,8 @@ export class TranslateService {
 
         // if this language is unavailable, ask for it
         if(typeof this.translations[lang] === "undefined") {
-            pending = this.getTranslation(lang);
+            this._translationRequests[lang] = this._translationRequests[lang] || this.getTranslation(lang);
+            pending = this._translationRequests[lang];
         }
 
         return pending;
@@ -475,6 +477,7 @@ export class TranslateService {
      * @param lang
      */
     public resetLang(lang: string): void {
+        this._translationRequests[lang] = undefined;
         this.translations[lang] = undefined;
     }
 

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -1,7 +1,7 @@
 import {Injector} from "@angular/core";
 import {TranslateService, TranslateLoader, LangChangeEvent, TranslationChangeEvent, TranslateModule} from '../index';
 import {Observable} from "rxjs/Observable";
-import {getTestBed, TestBed} from "@angular/core/testing";
+import {getTestBed, TestBed, fakeAsync, tick} from "@angular/core/testing";
 
 let translations: any = {"TEST": "This is a test"};
 class FakeLoader implements TranslateLoader {
@@ -296,4 +296,18 @@ describe('TranslateService', () => {
         expect(browserCultureLand).toBeDefined();
         expect(typeof browserCultureLand === 'string').toBeTruthy();
     });
+
+    it('should not make duplicate requests', fakeAsync(() => {
+        let getTranslationCalls = 0;
+        spyOn(translate.currentLoader, 'getTranslation').and.callFake(() => {
+            getTranslationCalls += 1;
+            return Observable.timer(1000).mapTo(Observable.of(translations));
+        });
+        translate.use('en');
+        translate.use('en');
+
+        tick(1001);
+
+        expect(getTranslationCalls).toEqual(1);
+    }));
 });


### PR DESCRIPTION
This stops multiple requests being made for the same lang file. It will now return the same observable when making duplicate requests for the same language.
Closes #397