### PR TITLE
fix(parser): treat '' as missing translation

### DIFF
--- a/src/translate.parser.ts
+++ b/src/translate.parser.ts
@@ -41,7 +41,7 @@ export class TranslateDefaultParser extends TranslateParser {
         key = '';
         do {
             key += keys.shift();
-            if(isDefined(target) && isDefined(target[key]) && (typeof target[key] === 'object' || !keys.length)) {
+            if(target && target[key]  && (typeof target[key] === 'object' || !keys.length)) {
                 target = target[key];
                 key = '';
             } else if(!keys.length) {


### PR DESCRIPTION
because ngx-translate-extract defaults translations to '', and untranslated tests should not suppress falling back to the default language

Fixes #487