### PR TITLE
feat(TranslateService): streaming translations that update on language change

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ To render them, simply use the `innerHTML` attribute with the pipe on any elemen
 - `addLangs(langs: Array<string>)`: Add new langs to the list
 - `getLangs()`: Returns an array of currently available langs
 - `get(key: string|Array<string>, interpolateParams?: Object): Observable<string|Object>`: Gets the translated value of a key (or an array of keys) or the key if the value was not found
+- `stream(key: string|Array<string>, interpolateParams?: Object): Observable<string|Object>`: Returns a stream of translated values of a key (or an array of keys) or the key if the value was not found. Without any `onLangChange` events this returns the same value as `get` but it will also emit new values whenever the used language changes.
 - `instant(key: string|Array<string>, interpolateParams?: Object): string|Object`: Gets the instant translated value of a key (or an array of keys). /!\ This method is **synchronous** and the default file loader is asynchronous. You are responsible for knowing when your translations have been loaded and it is safe to use this method. If you are not sure then you should use the `get` method instead.
 - `set(key: string, value: string, lang?: string)`: Sets the translated value of a key
 - `reloadLang(lang: string): Observable<string|Object>`: Calls resetLang and retrieves the translations object for the current loader

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -4,7 +4,9 @@ import {Observable} from "rxjs/Observable";
 import {getTestBed, TestBed, fakeAsync, tick} from "@angular/core/testing";
 
 import 'rxjs/add/observable/timer';
+import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/mapTo';
+import 'rxjs/add/operator/zip';
 
 let translations: any = {"TEST": "This is a test"};
 class FakeLoader implements TranslateLoader {
@@ -193,6 +195,90 @@ describe('TranslateService', () => {
             expect(translations).toEqual({});
             done();
         });
+    });
+
+    it('should be able to stream a translation for the current language', (done: Function) => {
+        translations = {"TEST": "This is a test"};
+        translate.use('en');
+
+        translate.stream('TEST').subscribe((res: string) => {
+            expect(res).toEqual('This is a test');
+            done();
+        });
+    });
+
+    it('should be able to stream a translation of an array for the current language', (done: Function) => {
+        let tr = {"TEST": "This is a test", "TEST2": "This is a test2"};
+        translate.setTranslation('en', tr);
+        translate.use('en');
+
+        translate.stream(['TEST', 'TEST2']).subscribe((res: any) => {
+            expect(res).toEqual(tr);
+            done();
+        });
+    });
+
+    it('should initially return the same value for streaming and non-streaming get', (done: Function) => {
+        translations = {"TEST": "This is a test"};
+        translate.use('en');
+
+        translate.stream('TEST').zip(translate.get('TEST')).subscribe((value: [string, string]) => {
+            const [streamed, nonStreamed] = value;
+            expect(streamed).toEqual('This is a test');
+            expect(streamed).toEqual(nonStreamed);
+            done();
+        });
+    });
+
+    it('should update streaming translations on language change', (done: Function) => {
+        translations = {"TEST": "This is a test"};
+        translate.use('en');
+
+        translate.stream('TEST').take(3).toArray().subscribe((res: string[]) => {
+            const expected = ['This is a test', 'Dit is een test', 'This is a test'];
+            expect(res).toEqual(expected);
+            done();
+        });
+
+        translate.setTranslation('nl', {"TEST": "Dit is een test"});
+        translate.use('nl');
+        translate.use('en');
+    });
+
+    it('should update streaming translations of an array on language change', (done: Function) => {
+        const en = {"TEST": "This is a test", "TEST2": "This is a test2"};
+        const nl = {"TEST": "Dit is een test", "TEST2": "Dit is een test2"};
+        translate.setTranslation('en', en);
+        translate.use('en');
+
+        translate.stream(['TEST', 'TEST2']).take(3).toArray().subscribe((res: any[]) => {
+            const expected = [en, nl, en];
+            expect(res).toEqual(expected);
+            done();
+        });
+
+        translate.setTranslation('nl', nl);
+        translate.use('nl');
+        translate.use('en');
+    });
+
+    it('should interpolate the same param into each streamed value', (done: Function) => {
+        translations = {"TEST": "This is a test {{param}}"};
+        translate.use('en');
+
+        translate.stream('TEST', { param: 'with param' }).take(3).toArray().subscribe((res: string[]) => {
+            const expected = [
+                'This is a test with param',
+                'Dit is een test with param',
+                'This is a test with param'
+            ];
+            expect(res).toEqual(expected);
+            done();
+        });
+
+        translate.setTranslation('nl', {"TEST": "Dit is een test {{param}}"});
+        translate.use('nl');
+        translate.use('en');
     });
 
     it('should be able to get instant translations', () => {


### PR DESCRIPTION
## Description

As mentioned in #330 this method would drastically simplify several of our components and allows for the idiomatic use of the `async` pipe with the `TranslationService` in the cases where using the `translate` pipe is - for some reason - undesirable. As a comparison:

Current:
```ts
@Component({ 
  template: `
    <div>{{a}}</div>
    <div>{{b}}</div>
    <div>{{c}}</div>
  `
})
export class TestComponent implements OnInit, OnDestroy {
  a: string;
  b: string;
  c: string;
  private subscription: Subscription<any>;

  constructor(private translate: TranslateService) { }

  ngOnInit() {
    this.subscription = this.translate.get(['a', 'b', 'c'])
      .concat(this.translate.onLangChange.map(event => event.translations))
      .subscribe(translations => {
        this.a = translations.a;
        this.b = translations.b;
        this.c = translations.c;
      });
  }

  ngOnDestroy() {
    this.subscription.unsubscribe();
  }
}
```

New (per-translation Observable):
```ts
@Component({ 
  template: `
    <div>{{a$ | async}}</div>
    <div>{{b$ | async}}</div>
    <div>{{c$ | async}}</div>
  `
})
export class TestComponent implements OnInit {
  a$: Observable<string>;
  b$: Observable<string>;
  c$: Observable<string>;

  constructor(private translate: TranslateService) { }

  ngOnInit() {
    this.a$ = this.translate.stream('a');
    this.b$ = this.translate.stream('b');
    this.c$ = this.translate.stream('c');
  }
}
```

New (array-based Observable):
```ts
@Component({ 
  template: `
    <ng-container *ngIf="translations$ | async as translation">
      <div>{{translation.a}}</div>
      <div>{{translation.b}}</div>
      <div>{{translation.c}}</div>
    </ng-container>
  `
})
export class TestComponent implements OnInit {
  translations$: Observable<{ [key: string]: string }>;

  constructor(private translate: TranslateService) { }

  ngOnInit() {
    this.translations$ = this.translate.stream(['a', 'b', 'c']);
  }
}
```

I want to note here that the middle solution is suboptimal: it creates 3 subscriptions instead of one. Still, the last example is pretty motivating I think: mostly everything is declarative and we don't have to bother with manually unsubscribing from any Observables.

## Implementation

I tried to mirror the implementation of `get/instant`, using the building blocks that are already there. Please tell me if there's anything to improve on (the same goes for the unit tests).

Closes #330