### PR TITLE
Support pluralization using messageformat.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,16 @@ export class SharedModule { }
 
 When you lazy load a module, you should use the `forChild` static method to import the `TranslateModule`.
 
-Since lazy loaded modules use a different injector from the rest of your application, you can configure them separately with a different loader/parser/missing translations handler.
+Since lazy loaded modules use a different injector from the rest of your application, you can configure them separately with a different loader/compiler/parser/missing translations handler.
 You can also isolate the service by using `isolate: true`. In which case the service is a completely isolated instance (for translations, current lang, events, ...).
-Otherwise, by default, it will share its data with other instances of the service (but you can still use a different loader/parser/handler even if you don't isolate the service).
+Otherwise, by default, it will share its data with other instances of the service (but you can still use a different loader/compiler/parser/handler even if you don't isolate the service).
 
 ```ts
 @NgModule({
     imports: [
         TranslateModule.forChild({
             loader: {provide: TranslateLoader, useClass: CustomLoader},
+            compiler: {provide: TranslateCompiler, useClass: CustomCompiler},
             parser: {provide: TranslateParser, useClass: CustomParser},
             missingTranslationHandler: {provide: MissingTranslationHandler, useClass: CustomHandler},
             isolate: true
@@ -342,6 +343,16 @@ Once you've defined your loader, you can provide it in your configuration by add
 })
 export class AppModule { }
 ```
+
+#### How to use a compiler to preprocess translation values
+
+By default, translation values are added "as-is". You can configure a `compiler` that implements `TranslateCompiler` to pre-process translation values when they are added (either manually or by a loader). A compiler has the following methods:
+
+- `compile(value: string, lang: string): string | Function`: Compiles a string to a function or another string.
+- `compileTranslations(translations: any, lang: string): any`:  Compiles a (possibly nested) object of translation values to a structurally identical object of compiled translation values. 
+
+Using a compiler opens the door for powerful pre-processing of translation values. As long as the compiler outputs a compatible interpolation string or an interpolation function, arbitrary input syntax can be supported.
+
 
 #### How to handle missing translations
 

--- a/README.md
+++ b/README.md
@@ -384,9 +384,10 @@ export class AppModule { }
 If you need it for some reason, you can use the `TranslateParser` service.
 
 #### Methods:
-- `interpolate(expr: string, params?: any): string`: Interpolates a string to replace parameters.
+- `interpolate(expr: string | Function, params?: any): string`: Interpolates a string to replace parameters or calls the interpolation function with the parameters.
 
     `This is a {{ key }}` ==> `This is a value` with `params = { key: "value" }`
+    `(params) => \`This is a ${params.key}\` ==> `This is a value` with `params = { key: "value" }`
 - `getValue(target: any, key: string): any`:  Gets a value from an object by composed key
      `parser.getValue({ key1: { keyA: 'valueI' }}, 'key1.keyA') ==> 'valueI'`
 

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import {TranslateLoader, TranslateFakeLoader} from "./src/translate.loader";
 import {TranslateService} from "./src/translate.service";
 import {MissingTranslationHandler, FakeMissingTranslationHandler} from "./src/missing-translation-handler";
 import {TranslateParser, TranslateDefaultParser} from "./src/translate.parser";
+import {TranslateCompiler, TranslateFakeCompiler} from "./src/translate.compiler";
 import {TranslateDirective} from "./src/translate.directive";
 import {TranslatePipe} from "./src/translate.pipe";
 import {TranslateStore} from "./src/translate.store";
@@ -12,11 +13,13 @@ export * from "./src/translate.loader";
 export * from "./src/translate.service";
 export * from "./src/missing-translation-handler";
 export * from "./src/translate.parser";
+export * from "./src/translate.compiler";
 export * from "./src/translate.directive";
 export * from "./src/translate.pipe";
 
 export interface TranslateModuleConfig {
     loader?: Provider;
+    compiler?: Provider;
     parser?: Provider;
     missingTranslationHandler?: Provider;
     // isolate the service instance, only works for lazy loaded modules or components with the "providers" property
@@ -44,6 +47,7 @@ export class TranslateModule {
             ngModule: TranslateModule,
             providers: [
                 config.loader || {provide: TranslateLoader, useClass: TranslateFakeLoader},
+                config.compiler || {provide: TranslateCompiler, useClass: TranslateFakeCompiler},
                 config.parser || {provide: TranslateParser, useClass: TranslateDefaultParser},
                 config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
                 TranslateStore,
@@ -63,6 +67,7 @@ export class TranslateModule {
             ngModule: TranslateModule,
             providers: [
                 config.loader || {provide: TranslateLoader, useClass: TranslateFakeLoader},
+                config.compiler || {provide: TranslateCompiler, useClass: TranslateFakeCompiler},
                 config.parser || {provide: TranslateParser, useClass: TranslateDefaultParser},
                 config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
                 {provide: USE_STORE, useValue: config.isolate},

--- a/src/translate.compiler.ts
+++ b/src/translate.compiler.ts
@@ -1,0 +1,20 @@
+import {Injectable} from "@angular/core";
+
+export abstract class TranslateCompiler {
+    abstract compile(value: string, lang: string): string | Function;
+    abstract compileTranslations(translations: any, lang: string): any;
+}
+
+/**
+ * This compiler is just a placeholder that does nothing, in case you don't need a compiler at all
+ */
+@Injectable()
+export class TranslateFakeCompiler extends TranslateCompiler {
+    compile(value: string, lang: string): string | Function {
+        return value;
+    }
+
+    compileTranslations(translations: any, lang: string): any {
+        return translations;
+    }
+}

--- a/tests/translate.compiler.spec.ts
+++ b/tests/translate.compiler.spec.ts
@@ -1,0 +1,111 @@
+import {Injector} from "@angular/core";
+import {TestBed, getTestBed} from "@angular/core/testing";
+import {TranslateService, TranslateModule, TranslateLoader, TranslateCompiler, TranslateFakeCompiler} from "../index";
+import {Observable} from "rxjs/Observable";
+
+let translations: any = {LOAD: 'This is a test'};
+
+class FakeLoader implements TranslateLoader {
+    getTranslation(lang: string): Observable<any> {
+        return Observable.of(translations);
+    }
+}
+
+describe('TranslateCompiler', () => {
+    let injector: Injector;
+    let translate: TranslateService;
+
+    let prepare = (_injector: Injector) => {
+        translate = _injector.get(TranslateService);
+    };
+
+    describe('with default TranslateFakeCompiler', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [
+                    TranslateModule.forRoot({
+                        loader: {provide: TranslateLoader, useClass: FakeLoader},
+                        compiler: {provide: TranslateCompiler, useClass: TranslateFakeCompiler}
+                    })
+                ],
+            });
+            injector = getTestBed();
+            prepare(injector);
+
+            translate.use('en');
+        });
+
+        it('should use the correct compiler', () => {
+            expect(translate).toBeDefined();
+            expect(translate.compiler).toBeDefined();
+            expect(translate.compiler instanceof TranslateFakeCompiler).toBeTruthy();
+        });
+
+        it('should use the compiler on loading translations', () => {
+            translate.get('LOAD').subscribe((res: string) => {
+                expect(res).toBe('This is a test');
+            });
+        });
+
+        it('should use the compiler on manually adding a translation object', () => {
+            translate.setTranslation('en', {'SET-TRANSLATION': 'A manually added translation'});
+            expect(translate.instant('SET-TRANSLATION')).toBe('A manually added translation');
+        });
+
+        it('should use the compiler on manually adding a single translation', () => {
+            translate.set('SET', 'Another manually added translation', 'en');
+            expect(translate.instant('SET')).toBe('Another manually added translation');
+        });
+    });
+
+    describe('with a custom compiler implementation', () => {
+        class CustomCompiler implements TranslateCompiler {
+            compile(value: string, lang: string): string {
+                return value + '|compiled';
+            }
+            compileTranslations(translation: any, lang: string): Object {
+                return Object.keys(translation).reduce((acc: any, key) => {
+                    acc[key] = () => translation[key] + '|compiled';
+                    return acc;
+                }, {});
+            }
+        }
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [
+                    TranslateModule.forRoot({
+                        loader: {provide: TranslateLoader, useClass: FakeLoader},
+                        compiler: {provide: TranslateCompiler, useClass: CustomCompiler}
+                    })
+                ],
+            });
+            injector = getTestBed();
+            prepare(injector);
+
+            translate.use('en');
+        });
+
+        it('should use the correct compiler', () => {
+            expect(translate).toBeDefined();
+            expect(translate.compiler).toBeDefined();
+            expect(translate.compiler instanceof CustomCompiler).toBeTruthy();
+        });
+
+        it('should use the compiler on loading translations', () => {
+            translate.get('LOAD').subscribe((res: string) => {
+                expect(res).toBe('This is a test|compiled');
+            });
+        });
+
+        it('should use the compiler on manually adding a translation object', () => {
+            translate.setTranslation('en', {'SET-TRANSLATION': 'A manually added translation'});
+            expect(translate.instant('SET-TRANSLATION')).toBe('A manually added translation|compiled');
+        });
+
+        it('should use the compiler on manually adding a single translation', () => {
+            translate.set('SET', 'Another manually added translation', 'en');
+            expect(translate.instant('SET')).toBe('Another manually added translation|compiled');
+        });
+    });
+});

--- a/tests/translate.parser.spec.ts
+++ b/tests/translate.parser.spec.ts
@@ -13,18 +13,22 @@ describe('Parser', () => {
         expect(parser instanceof TranslateParser).toBeTruthy();
     });
 
-    it('should interpolate', () => {
+    it('should interpolate strings', () => {
         expect(parser.interpolate("This is a {{ key }}", {key: "value"})).toEqual("This is a value");
     });
 
-    it('should interpolate with falsy values', () => {
+    it('should interpolate strings with falsy values', () => {
         expect(parser.interpolate("This is a {{ key }}", {key: ""})).toEqual("This is a ");
         expect(parser.interpolate("This is a {{ key }}", {key: 0})).toEqual("This is a 0");
     });
 
-    it('should interpolate with object properties', () => {
+    it('should interpolate strings with object properties', () => {
         expect(parser.interpolate("This is a {{ key1.key2 }}", {key1: {key2: "value2"}})).toEqual("This is a value2");
         expect(parser.interpolate("This is a {{ key1.key2.key3 }}", {key1: {key2: {key3: "value3"}}})).toEqual("This is a value3");
+    });
+
+    it('should support interpolation functions', () => {
+        expect(parser.interpolate((v: string) => v.toUpperCase() + ' YOU!', 'bless')).toBe('BLESS YOU!');
     });
 
     it('should get the addressed value', () => {


### PR DESCRIPTION
This PR aims to add support for the ICU message format syntax with the help of messageformat.js. I tried to find a way of integrating this with the current ngx-translate framework in a minimally invasive way. Here's the idea:

* Extend `TranslateParser.interpolate()` to not only support string interpolation but also function interpolation: `interpolate(fn, params) => fn(params)`
* Add a new configurable `TranslateCompiler` component which allows pre-processing translation values. This is an optional step and does nothing by default.
* Add a `TranslateMessageFormatCompiler` which compiles the translation values (expected to use the ICU syntax) into interpolation functions using messageformat.js.

Corresponding issue: https://github.com/ngx-translate/core/issues/150

**Edit:** If the dependency on messageformat.js is a concern, `TranslateMessageFormatCompiler` could easily be pulled in as a separate package of course, same as the "loaders". Only the first two points above affect the core. I guess this comes down to how popular one expects the ICU syntax to be with ngx-translate users.