### PR TITLE
feat: Parser API support

### DIFF
--- a/src/translate.parser.ts
+++ b/src/translate.parser.ts
@@ -18,7 +18,7 @@ export class TranslateDefaultParser extends TranslateParser {
     templateMatcher: RegExp = /{{\s?([^{}\s]*)\s?}}/g;
 
     public parse(translations: any, key: any, params?: any): string {
-        return this.interpolate(TranslateDefaultParser.getValue(translations, key), params);
+        return this.interpolate(this.getValue(translations, key), params);
     }
 
     protected interpolate(expr: any, params?: any): string {
@@ -27,12 +27,12 @@ export class TranslateDefaultParser extends TranslateParser {
         }
 
         return expr.replace(this.templateMatcher, (substring: string, b: string) => {
-            let r = TranslateDefaultParser.getValue(params, b);
+            let r = this.getValue(params, b);
             return isDefined(r) ? r : substring;
         });
     }
 
-    protected static getValue(target: any, key: any): string {
+    protected getValue(target: any, key: any): string {
         let keys = key.toString().split('.');
         key = '';
         do {

--- a/src/translate.parser.ts
+++ b/src/translate.parser.ts
@@ -3,41 +3,37 @@ import {isDefined} from "./util";
 
 export abstract class TranslateParser {
     /**
-     * Interpolates a string to replace parameters
+     * Retrieves a translated value from the a set of translations and interpolates it with the parameters provided
      * "This is a {{ key }}" ==> "This is a value", with params = { key: "value" }
-     * @param expr
+     * @param translations
+     * @param key
      * @param params
      * @returns {string}
      */
-    abstract interpolate(expr: string, params?: any): string;
-
-    /**
-     * Gets a value from an object by composed key
-     * parser.getValue({ key1: { keyA: 'valueI' }}, 'key1.keyA') ==> 'valueI'
-     * @param target
-     * @param key
-     * @returns {string}
-     */
-    abstract getValue(target: any, key: string): string
+    abstract parse(translations: any, key: any, params?: any): string
 }
 
 @Injectable()
 export class TranslateDefaultParser extends TranslateParser {
     templateMatcher: RegExp = /{{\s?([^{}\s]*)\s?}}/g;
 
-    public interpolate(expr: string, params?: any): string {
+    public parse(translations: any, key: any, params?: any): string {
+        return this.interpolate(TranslateDefaultParser.getValue(translations, key), params);
+    }
+
+    protected interpolate(expr: any, params?: any): string {
         if(typeof expr !== 'string' || !params) {
             return expr;
         }
 
         return expr.replace(this.templateMatcher, (substring: string, b: string) => {
-            let r = this.getValue(params, b);
+            let r = TranslateDefaultParser.getValue(params, b);
             return isDefined(r) ? r : substring;
         });
     }
 
-    getValue(target: any, key: string): string {
-        let keys = key.split('.');
+    protected static getValue(target: any, key: any): string {
+        let keys = key.toString().split('.');
         key = '';
         do {
             key += keys.shift();

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -345,11 +345,11 @@ export class TranslateService {
         }
 
         if(translations) {
-            res = this.parser.interpolate(this.parser.getValue(translations, key), interpolateParams);
+            res = this.parser.parse(translations, key, interpolateParams);
         }
 
         if(typeof res === "undefined" && this.defaultLang && this.defaultLang !== this.currentLang) {
-            res = this.parser.interpolate(this.parser.getValue(this.translations[this.defaultLang], key), interpolateParams);
+            res = this.parser.parse(this.translations[this.defaultLang], key, interpolateParams);
         }
 
         if(typeof res === "undefined") {

--- a/tests/translate.parser.spec.ts
+++ b/tests/translate.parser.spec.ts
@@ -13,33 +13,33 @@ describe('Parser', () => {
         expect(parser instanceof TranslateParser).toBeTruthy();
     });
 
-    it('should interpolate', () => {
-        expect(parser.interpolate("This is a {{ key }}", {key: "value"})).toEqual("This is a value");
+    it('should parse', () => {
+        expect(parser.parse({token: "This is a {{ key }}"}, 'token', {key: "value"})).toEqual("This is a value");
     });
 
-    it('should interpolate with falsy values', () => {
-        expect(parser.interpolate("This is a {{ key }}", {key: ""})).toEqual("This is a ");
-        expect(parser.interpolate("This is a {{ key }}", {key: 0})).toEqual("This is a 0");
+    it('should parse with falsy values', () => {
+        expect(parser.parse({token: "This is a {{ key }}"}, 'token', {key: ""})).toEqual("This is a ");
+        expect(parser.parse({token: "This is a {{ key }}"}, 'token', {key: 0})).toEqual("This is a 0");
     });
 
-    it('should interpolate with object properties', () => {
-        expect(parser.interpolate("This is a {{ key1.key2 }}", {key1: {key2: "value2"}})).toEqual("This is a value2");
-        expect(parser.interpolate("This is a {{ key1.key2.key3 }}", {key1: {key2: {key3: "value3"}}})).toEqual("This is a value3");
+    it('should parse with object properties', () => {
+        expect(parser.parse({token: "This is a {{ key1.key2 }}"}, 'token', {key1: {key2: "value2"}})).toEqual("This is a value2");
+        expect(parser.parse({token: "This is a {{ key1.key2.key3 }}"}, 'token', {key1: {key2: {key3: "value3"}}})).toEqual("This is a value3");
     });
 
     it('should get the addressed value', () => {
-        expect(parser.getValue({key1: {key2: "value2"}}, 'key1.key2')).toEqual("value2");
-        expect(parser.getValue({key1: {key2: "value"}}, 'keyWrong.key2')).not.toBeDefined();
-        expect(parser.getValue({key1: {key2: {key3: "value3"}}}, 'key1.key2.key3')).toEqual("value3");
-        expect(parser.getValue({key1: {key2: {key3: "value3"}}}, 'key1.keyWrong.key3')).not.toBeDefined();
-        expect(parser.getValue({key1: {key2: {key3: "value3"}}}, 'key1.key2.keyWrong')).not.toBeDefined();
+        expect(parser.parse({key1: {key2: "value2"}}, 'key1.key2')).toEqual("value2");
+        expect(parser.parse({key1: {key2: "value"}}, 'keyWrong.key2')).not.toBeDefined();
+        expect(parser.parse({key1: {key2: {key3: "value3"}}}, 'key1.key2.key3')).toEqual("value3");
+        expect(parser.parse({key1: {key2: {key3: "value3"}}}, 'key1.keyWrong.key3')).not.toBeDefined();
+        expect(parser.parse({key1: {key2: {key3: "value3"}}}, 'key1.key2.keyWrong')).not.toBeDefined();
 
 
-        expect(parser.getValue({'key1.key2': {key3: "value3"}}, 'key1.key2.key3')).toEqual("value3");
-        expect(parser.getValue({key1: {'key2.key3': "value3"}}, 'key1.key2.key3')).toEqual("value3");
-        expect(parser.getValue({'key1.key2.key3': "value3"}, 'key1.key2.key3')).toEqual("value3");
-        expect(parser.getValue({'key1.key2': {key3: "value3"}}, 'key1.key2.keyWrong')).not.toBeDefined();
-        expect(parser.getValue({
+        expect(parser.parse({'key1.key2': {key3: "value3"}}, 'key1.key2.key3')).toEqual("value3");
+        expect(parser.parse({key1: {'key2.key3': "value3"}}, 'key1.key2.key3')).toEqual("value3");
+        expect(parser.parse({'key1.key2.key3': "value3"}, 'key1.key2.key3')).toEqual("value3");
+        expect(parser.parse({'key1.key2': {key3: "value3"}}, 'key1.key2.keyWrong')).not.toBeDefined();
+        expect(parser.parse({
             'key1': "value1",
             'key1.key2': "value2"
         }, 'key1.key2')).toEqual("value2");


### PR DESCRIPTION
This tweak to the API allows for non-string constructs to be passed as keys and have them be interpreted against the set of translations. Also, it simplifies the API in the translation service.

This will allow for a parser that can handle interpretable (and recursive) constructs like the following:

```
export class TranslatableToken {
    constructor(public key: string, public params?: any) {
    }
}

export class AlternativeParser extends TranslateDefaultParser {

    public parse(translations: any, key: any, params?: any): string {
        if(key instanceof TranslatableToken) {
            if(key.params) {
                if(params) {
                    params = Object.assign(this._parseTranslatableValues(translations, key.params), params);
                } else {
                    params = this._parseTranslatableValues(translations, key.params);
                }
            }
            key = key.key;
        }
        return super.parse(translations, key, params);
    }

    private _parseTranslatableValues(translations: any, values: any): {} {
        let ret: any = {};
        for(let key in values) {
            if(values.hasOwnProperty(key)) {
                let value: any = values[key];
                if(value instanceof TranslatableToken) {
                    value = super.parse(translations, value.key, this._parseTranslatableValues(translations, value.params));
                }
                ret[key] = value;
            }
        }
        return ret;
    }
}
```