### PR TITLE
feat-TranslateService: default language translation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ export class AppModule { }
 
 You can setup a provider for the `MissingTranslationHandler` in the bootstrap of your application (recommended), or in the `providers` property of a component. It will be called when the requested translation is not available. The only required method is `handle` where you can do whatever you want. If this method returns a value or an observable (that should return a string), then this will be used. Just don't forget that it will be called synchronously from the `instant` method.
 
+You can use `useDefaultLang` to decide whether default language string should be used when there is a missing translation in current language. Default value is true. If you set it to false, `MissingTranslationHandler` will be used instead of the default language string.
+
 ##### Example:
 
 Create a Missing Translation Handler
@@ -375,7 +377,8 @@ Setup the Missing Translation Handler in your module import by adding it to the 
     imports: [
         BrowserModule,
         TranslateModule.forRoot({
-            missingTranslationHandler: {provide: MissingTranslationHandler, useClass: MyMissingTranslationHandler}
+            missingTranslationHandler: {provide: MissingTranslationHandler, useClass: MyMissingTranslationHandler},
+            useDefaultLang: false
         })
     ],
     providers: [

--- a/index.ts
+++ b/index.ts
@@ -41,7 +41,7 @@ export class TranslateModule {
      * @param {TranslateModuleConfig} config
      * @returns {ModuleWithProviders}
      */
-    static forRoot(config: TranslateModuleConfig = {useDefaultLang: true}): ModuleWithProviders {
+    static forRoot(config: TranslateModuleConfig = {}): ModuleWithProviders {
         return {
             ngModule: TranslateModule,
             providers: [
@@ -61,7 +61,7 @@ export class TranslateModule {
      * @param {TranslateModuleConfig} config
      * @returns {ModuleWithProviders}
      */
-    static forChild(config: TranslateModuleConfig = {useDefaultLang: true}): ModuleWithProviders {
+    static forChild(config: TranslateModuleConfig = {}): ModuleWithProviders {
         return {
             ngModule: TranslateModule,
             providers: [

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import {TranslateDirective} from "./src/translate.directive";
 import {TranslatePipe} from "./src/translate.pipe";
 import {TranslateStore} from "./src/translate.store";
 import {USE_STORE} from "./src/translate.service";
+import {USE_DEFAULT_LANG} from "./src/translate.service";
 
 export * from "./src/translate.loader";
 export * from "./src/translate.service";
@@ -21,6 +22,7 @@ export interface TranslateModuleConfig {
     missingTranslationHandler?: Provider;
     // isolate the service instance, only works for lazy loaded modules or components with the "providers" property
     isolate?: boolean;
+    useDefaultLang?: boolean;
 }
 
 @NgModule({
@@ -48,6 +50,7 @@ export class TranslateModule {
                 config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
                 TranslateStore,
                 {provide: USE_STORE, useValue: config.isolate},
+                {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
                 TranslateService
             ]
         };
@@ -66,6 +69,7 @@ export class TranslateModule {
                 config.parser || {provide: TranslateParser, useClass: TranslateDefaultParser},
                 config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
                 {provide: USE_STORE, useValue: config.isolate},
+                {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
                 TranslateService
             ]
         };

--- a/index.ts
+++ b/index.ts
@@ -41,7 +41,7 @@ export class TranslateModule {
      * @param {TranslateModuleConfig} config
      * @returns {ModuleWithProviders}
      */
-    static forRoot(config: TranslateModuleConfig = {}): ModuleWithProviders {
+    static forRoot(config: TranslateModuleConfig = {useDefaultLang: true}): ModuleWithProviders {
         return {
             ngModule: TranslateModule,
             providers: [
@@ -61,7 +61,7 @@ export class TranslateModule {
      * @param {TranslateModuleConfig} config
      * @returns {ModuleWithProviders}
      */
-    static forChild(config: TranslateModuleConfig = {}): ModuleWithProviders {
+    static forChild(config: TranslateModuleConfig = {useDefaultLang: true}): ModuleWithProviders {
         return {
             ngModule: TranslateModule,
             providers: [

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -161,7 +161,7 @@ export class TranslateService {
                 public currentLoader: TranslateLoader,
                 public parser: TranslateParser,
                 public missingTranslationHandler: MissingTranslationHandler,
-                @Inject(USE_DEFAULT_LANG)private useDefaultLang: boolean = true,
+                @Inject(USE_DEFAULT_LANG) private useDefaultLang: boolean = true,
                 @Inject(USE_STORE) private isolate: boolean = false) {
     }
 

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -17,6 +17,7 @@ import {TranslateParser} from "./translate.parser";
 import {mergeDeep, isDefined} from "./util";
 
 export const USE_STORE = new OpaqueToken('USE_STORE');
+export const USE_DEFAULT_LANG = new OpaqueToken('USE_DEFAULT_LANG');
 
 export interface TranslationChangeEvent {
     translations: any;
@@ -154,11 +155,13 @@ export class TranslateService {
      * @param parser An instance of the parser currently used
      * @param missingTranslationHandler A handler for missing translations.
      * @param isolate whether this service should use the store or not
+     * @param useDefaultLang whether we should use default language translation when current language translation is missing.
      */
     constructor(public store: TranslateStore,
                 public currentLoader: TranslateLoader,
                 public parser: TranslateParser,
                 public missingTranslationHandler: MissingTranslationHandler,
+                @Inject(USE_DEFAULT_LANG)private useDefaultLang: boolean = true,
                 @Inject(USE_STORE) private isolate: boolean = false) {
     }
 
@@ -348,7 +351,7 @@ export class TranslateService {
             res = this.parser.interpolate(this.parser.getValue(translations, key), interpolateParams);
         }
 
-        if(typeof res === "undefined" && this.defaultLang && this.defaultLang !== this.currentLang) {
+        if(typeof res === "undefined" && this.defaultLang && this.defaultLang !== this.currentLang && this.useDefaultLang) {
             res = this.parser.interpolate(this.parser.getValue(this.translations[this.defaultLang], key), interpolateParams);
         }
 


### PR DESCRIPTION
feat(TranslateService): default language translation when current language translation is missing is now configurable.

As it is now, if KEY isn't found in current language translation, translation from default language is returned. If there isn't KEY in default language, MissingHandler is invoked. 

This PR aims to make translation to default language configurable.

In some instances we don't want default translation to mix with current translation, and we want MissingHandler to jump in instead.