### PR TITLE
docs(firebase-example): Prefix should be in the constructor

### DIFF
--- a/FIREBASE_EXAMPLE.md
+++ b/FIREBASE_EXAMPLE.md
@@ -10,9 +10,10 @@ import { Observable } from 'rxjs/Observable';
 import { AngularFireDatabase} from 'angularfire2/database';
 
 export class FirebaseTransLoader implements TranslateLoader {
-	constructor(private db: AngularFireDatabase) {}
-	public getTranslation(lang: string, prefix: string = 'translations/'): any {
-		return this.db.object(`${prefix}${lang}`) as Observable<any>;
+	constructor(private db: AngularFireDatabase, private prefix: string = 'translations/') {}
+	public getTranslation(lang: string): any {
+		return this.db.object(`${this.prefix}${lang}`) as Observable<any>;
+
 	}
 }
 ```


### PR DESCRIPTION
Fixes a 'typo' which confused me, when I made a custom loader by following this example.