### PR TITLE
Fix typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ you can export the `TranslateModule` to make sure you don't have to import it in
 
 ```ts
 @NgModule({
-    exports: [
+    imports: [
         CommonModule,
         TranslateModule
     ]


### PR DESCRIPTION
The CommonModule and the TranslateModule needs to be imported, not exported