### PR TITLE
Fix when the pending state is true, the translation is not compiled by the compiler.

### DIFF
--- a/lib/src/translate.service.ts
+++ b/lib/src/translate.service.ts
@@ -404,7 +404,7 @@ export class TranslateService {
                     observer.error(err);
                 };
                 this.loadingTranslations.subscribe((res: any) => {
-                    res = this.getParsedResult(res, key, interpolateParams);
+                    res = this.getParsedResult(this.compiler.compileTranslations(res, this.currentLang), key, interpolateParams);
                     if(typeof res.subscribe === "function") {
                         res.subscribe(onComplete, onError);
                     } else {


### PR DESCRIPTION
Hi, the change fixes an issue that when the translation is in pending state, the compiler will not compile the translation and the strings on the first loaded web page are not compiled.   