### PR TITLE
merge translation object in default instead of replacing it

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -280,7 +280,7 @@ export class TranslateService {
      * @param translations
      * @param shouldMerge
      */
-    public setTranslation(lang: string, translations: Object, shouldMerge: boolean = false): void {
+    public setTranslation(lang: string, translations: Object, shouldMerge: boolean = true): void {
         translations = this.compiler.compileTranslations(translations, lang);
         if(shouldMerge && this.translations[lang]) {
             this.translations[lang] = mergeDeep(this.translations[lang], translations);


### PR DESCRIPTION
the default value of  `shouldMerge` of `setTranslation()` is false, which makes it easy to overwrite the existed translation unexpectly, I think it is better to merge the translation objects than replace it.