### PR TITLE
ngx-translate-zombies vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ If you're using an old version of Angular and ngx-translate requires a newer ver
 - [.po files Loader](https://github.com/biesbjerg/ngx-translate-po-http-loader) by @biesbjerg: Use .po translation files with ngx-translate
 - [ngx-translate-extract](https://github.com/biesbjerg/ngx-translate-extract) by @biesbjerg: Extract translatable strings from your projects
 - [MessageFormat Compiler](https://github.com/lephyrus/ngx-translate-messageformat-compiler) by @lephyrus: Compiler for ngx-translate that uses messageformat.js to compile translations using ICU syntax for handling pluralization, gender, and more
+- [ngx-translate-zombies](https://marketplace.visualstudio.com/items?itemName=seveseves.ngx-translate-zombies) by @seveves: A vscode extension that finds unused translation keys and shows them in a diff view (so called zombies).
 
 ## Additional Framework Support
 


### PR DESCRIPTION
I wrote a simple vscode extension for ngx-translate. When you have f.e. your english translation file ```en.json``` opened then you can hit ```F1``` and type ```ngxtz: find translation zombies in this file``` and hit return. The extension will search through all .ts, .js and .html files (excluding node_modules) and show a changed version of ```en.json``` in the vscode diff editor.

I needed this for my daily work and just wrote it ... so of course at the moment it only has very basic features but it's OSS and you can contribute if you want to :)