### PR TITLE
fix(TranslateService): shouldMerge option now does merging with lodash

### DIFF
--- a/lib/src/util.ts
+++ b/lib/src/util.ts
@@ -61,8 +61,6 @@ export function isObject(item: any): boolean {
 }
 
 export function mergeDeep(target: any, source: any): any {
-    target = JSON.parse(JSON.stringify(target));
-    source = JSON.parse(JSON.stringify(source));
     let output = Object.assign({}, target);
     if (isObject(target) && isObject(source)) {
         Object.keys(source).forEach((key: any) => {

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -183,6 +183,20 @@ describe('TranslateService', () => {
         });
     });
 
+    it("should merge non-valid JSON translations if option shouldMerge is true", () => {
+        translations = {};
+        translate.setTranslation('en', { "TEST": { "sub1": () => "value1" } }, true);
+        translate.setTranslation('en', { "TEST": { "sub2": () => "value2" } }, true);
+        translate.use('en');
+
+        translate.get('TEST.sub1').subscribe((res: string) => {
+          expect(res).toEqual('value1');
+        });
+        translate.get('TEST.sub2').subscribe((res: string) => {
+          expect(res).toEqual('value2');
+        });
+    });
+
     it("shouldn't call the current loader if you set the translation yourself", (done: Function) => {
         translations = {};
         translate.setTranslation('en', {"TEST": "This is a test"});


### PR DESCRIPTION
shouldMerge option of the `setTranslation` method didn't handle non-valid JSON translations object such compiled translations with custom compiler.
It is now doing deep merging with lodash.
Fixes #764