### PR TITLE
add option to show keys and not translation

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -36,7 +36,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
   }
 
   transform(query: string, ...args: any[]): any {
-    if (!query || query.length === 0) {
+    if (!query || query.length === 0 || window.desactivate_ngx_translate ) {
       return query;
     }
 

--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -36,7 +36,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
   }
 
   transform(query: string, ...args: any[]): any {
-    if (!query || query.length === 0 || window.desactivate_ngx_translate ) {
+    if (!query || query.length === 0 || (window as any).desactivate_ngx_translate ) {
       return query;
     }
 


### PR DESCRIPTION
- Allows users to see what is the key for a specific translation, in order to find quickly the value to change in .json
- My users have problem to find what key to change on our website. So they could add `window.desactivate_ngx_translate` in the console, and it would show keys and not translated values.