### PR TITLE
Add option to merge translations fetched by the loader

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -98,6 +98,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
   updateValue(key: string, node: any, translations: any) {
     if (key) {
       if (node.lastKey === key && this.lastParams === this.currentParams) {
+        this.setContent(node, node.currentValue);
         return;
       }
 

--- a/projects/ngx-translate/core/src/public_api.ts
+++ b/projects/ngx-translate/core/src/public_api.ts
@@ -9,6 +9,7 @@ import {TranslatePipe} from "./lib/translate.pipe";
 import {TranslateStore} from "./lib/translate.store";
 import {USE_STORE} from "./lib/translate.service";
 import {USE_DEFAULT_LANG} from "./lib/translate.service";
+import {SHOULD_MERGE} from "./lib/translate.service";
 
 export * from "./lib/translate.loader";
 export * from "./lib/translate.service";
@@ -27,6 +28,7 @@ export interface TranslateModuleConfig {
   // isolate the service instance, only works for lazy loaded modules or components with the "providers" property
   isolate?: boolean;
   useDefaultLang?: boolean;
+  shouldMerge?: boolean;
 }
 
 @NgModule({
@@ -54,6 +56,7 @@ export class TranslateModule {
         TranslateStore,
         {provide: USE_STORE, useValue: config.isolate},
         {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
+        {provide: SHOULD_MERGE, useValue: config.shouldMerge},
         TranslateService
       ]
     };
@@ -72,6 +75,7 @@ export class TranslateModule {
         config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
         {provide: USE_STORE, useValue: config.isolate},
         {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
+        {provide: SHOULD_MERGE, useValue: config.shouldMerge},
         TranslateService
       ]
     };


### PR DESCRIPTION
Update: I have updated the implementation due to the directive not working properly.

Explanation: This is useful for components shipping in a library which already provided translations via in-memory setTranslation() before theTranslateLoader had a chance to kick in. With this change you can provide TranslateModuleConfig.shouldMerge for the loader which in turn fetches the translations and merges them with the existing ones.