### PR TITLE
fix(TranslatePipe): handle non string input

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -36,7 +36,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
   }
 
   transform(query: string, ...args: any[]): any {
-    if (!query || query.length === 0) {
+    if (!query || !query.length) {
       return query;
     }
 

--- a/projects/ngx-translate/core/tests/translate.pipe.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.pipe.spec.ts
@@ -161,6 +161,15 @@ describe('TranslatePipe', () => {
     }).toThrowError(`Wrong parameter in TranslatePipe. Expected a valid Object, received: ${param}`);
   });
 
+  it("should return given falsey or non length query", () => {
+    translate.setTranslation('en', {"TEST": "This is a test"});
+    translate.use('en');
+
+    expect(translatePipe.transform(null)).toBeNull();
+    expect(translatePipe.transform(undefined)).toBeUndefined();
+    expect(translatePipe.transform(1234 as any)).toBe(1234);
+  });
+
   describe('should update translations on lang change', () => {
     it('with fake loader', (done) => {
       translate.setTranslation('en', {"TEST": "This is a test"});


### PR DESCRIPTION
Forgive me I didn't see a contributing guideline and I wasn't sure if I sure file a bug for this/wanted to start more of a discussion about how TranslatePipe should handle non-string input.

### Preface
I write shared components for other teams to use (think asset kit), and don't have strict control over inputs. We can put in arg validation as needed but I did run into a case that IMO the TranslatePipe should handle on its own.

### Problem
TranslatePipe throws a `Parameter "key" required` error for `number` type input. IMO this could just return back the number that was passed in, curious on others' opinions?

### Example
We have a shared filtering/searching component that displays a list of filter labels the user can select from such as:

![image](https://user-images.githubusercontent.com/12201405/42715474-6f2c9810-86b4-11e8-9a7a-edb3d527791e.png)

The basic replication code boils down to:
```html
<span>{{ 2018 | translate }}</span>
```
Which throws the `Parameter "key" required` error.

### Solution
Return back the original `query` arg if it is falsey or the `.length` call is falesy.

### Discussion
Curious if others agree if this should be the functionality or if I have to resort to coercing all inputs to strings in my components.

---
@ocombe 