### PR TITLE
Fix #707: Allow parameters in translation keys

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.parser.ts
+++ b/projects/ngx-translate/core/src/lib/translate.parser.ts
@@ -5,6 +5,7 @@ export abstract class TranslateParser {
   /**
    * Interpolates a string to replace parameters
    * "This is a {{ key }}" ==> "This is a value", with params = { key: "value" }
+   * "This is a { key }" ==> "This is a value", with params = { key: "value" }
    * @param expr
    * @param params
    */
@@ -21,7 +22,7 @@ export abstract class TranslateParser {
 
 @Injectable()
 export class TranslateDefaultParser extends TranslateParser {
-  templateMatcher: RegExp = /{{\s?([^{}\s]*)\s?}}/g;
+  templateMatcher: RegExp = /{{1,2}\s?([^{}\s]*)\s?}{1,2}/g;
 
   public interpolate(expr: string | Function, params?: any): string {
     let result: string;

--- a/projects/ngx-translate/core/tests/translate.parser.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.parser.spec.ts
@@ -15,11 +15,14 @@ describe('Parser', () => {
 
   it('should interpolate strings', () => {
     expect(parser.interpolate("This is a {{ key }}", {key: "value"})).toEqual("This is a value");
+    expect(parser.interpolate("This is a { key }", {key: "value"})).toEqual("This is a value");
   });
 
   it('should interpolate strings with falsy values', () => {
     expect(parser.interpolate("This is a {{ key }}", {key: ""})).toEqual("This is a ");
     expect(parser.interpolate("This is a {{ key }}", {key: 0})).toEqual("This is a 0");
+    expect(parser.interpolate("This is a { key }", {key: ""})).toEqual("This is a ");
+    expect(parser.interpolate("This is a { key }", {key: 0})).toEqual("This is a 0");
   });
 
   it('should interpolate strings with object properties', () => {


### PR DESCRIPTION
Example: <button>{{ 'Log out ({ email })' | translate: { email: (user$ | async)?.email } }}</button>