### PR TITLE
fix(TranslateService): check whether variable contains undefined value

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -497,6 +497,10 @@ export class TranslateService {
     let browserLang: any = window.navigator.languages ? window.navigator.languages[0] : null;
     browserLang = browserLang || window.navigator.language || window.navigator.browserLanguage || window.navigator.userLanguage;
 
+    if (typeof browserLang === 'undefined') {
+      return undefined
+    }
+
     if (browserLang.indexOf('-') !== -1) {
       browserLang = browserLang.split('-')[0];
     }


### PR DESCRIPTION
When accessing a non-existing property, JavaScript returns undefined.
The check for 'undefined' will guarantee that browserLang has been and we can safely call .indexOf()