### PR TITLE
fix(directive): avoid recursive errors when using keys with whitespaces

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -69,17 +69,24 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
       let node: any = nodes[i];
       if (node.nodeType === 3) { // node type 3 is a text node
         let key: string;
-        if (this.key) {
+        if (forceUpdate) {
+          node.lastKey = null;
+        }
+        if(isDefined(node.lookupKey)) {
+          key = node.lookupKey;
+        } else if (this.key) {
           key = this.key;
-          if (forceUpdate) {
-            node.lastKey = null;
-          }
         } else {
           let content = this.getContent(node);
           let trimmedContent = content.trim();
           if (trimmedContent.length) {
-            if (node.originalContent && forceUpdate) { // the content seems ok, but the lang has changed
-              node.lastKey = null;
+            node.lookupKey = trimmedContent;
+            // we want to use the content as a key, not the translation value
+            if (content !== node.currentValue) {
+              key = trimmedContent;
+              // the content was changed from the user, we'll use it as a reference if needed
+              node.originalContent = content || node.originalContent;
+            } else if (node.originalContent) { // the content seems ok, but the lang has changed
               // the current content is the translation, not the key, use the last real content as key
               key = node.originalContent.trim();
             } else if (content !== node.currentValue) {


### PR DESCRIPTION
The problem with issue #998 is, that at some node.originalContent in translate.directive.ts is overwritten by a translation that was assigned previously. So the translation key gets destroyed and no further translations could be made.

The bugfix introduces a new variable (node.lookupKey) that is generated once (by this.key or the trimmed content of the node) and used in further translations instead of calculating it over and over again. 

Since I changed no existing tests, I assume that alle existing functionality still works. I added new test to verify that the problem with white spaces are fixed.