### PR TITLE
fix(service) handle non-string keys without throwing

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.parser.ts
+++ b/projects/ngx-translate/core/src/lib/translate.parser.ts
@@ -39,7 +39,7 @@ export class TranslateDefaultParser extends TranslateParser {
   }
 
   getValue(target: any, key: string): any {
-    let keys = key.split('.');
+    let keys = typeof key === 'string' ? key.split('.') : [key];
     key = '';
     do {
       key += keys.shift();


### PR DESCRIPTION
This is a corner case, but broke the app in my case cause a number was translated