### PR TITLE
feat(service): add option to set default language in root config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,25 @@ export function createTranslateLoader(http: HttpClient) {
 export class AppModule { }
 ```
 
-#### 2. Init the `TranslateService` for your application:
+#### 2. Define the `default language` for the application
+
+```ts
+@NgModule({
+    imports: [
+        BrowserModule,
+        TranslateModule.forRoot({
+            defaultLanguage: 'en'
+        })
+    ],
+    providers: [
+
+    ],
+    bootstrap: [AppComponent]
+})
+export class AppModule { }
+```
+
+#### 3. Init the `TranslateService` for your application:
 
 ```ts
 import {Component} from '@angular/core';
@@ -229,7 +247,7 @@ export class AppComponent {
 }
 ```
 
-#### 3. Define the translations:
+#### 4. Define the translations:
 
 Once you've imported the `TranslateModule`, you can put your translations in a json file that will be imported with the `TranslateHttpLoader`. The following translations should be stored in `en.json`.
 
@@ -259,7 +277,7 @@ The `TranslateParser` understands nested JSON objects. This means that you can h
 
 You can then access the value by using the dot notation, in this case `HOME.HELLO`.
 
-#### 4. Use the service, the pipe or the directive:
+#### 5. Use the service, the pipe or the directive:
 
 You can either use the `TranslateService`, the `TranslatePipe` or the `TranslateDirective` to get your translation values.
 
@@ -326,7 +344,7 @@ Or even simpler using the content of your element as a key:
 <div translate [translateParams]="{value: 'world'}">HELLO</div>
 ```
 
-#### 5. Use HTML tags:
+#### 6. Use HTML tags:
 
 You can easily use raw HTML tags within your translations.
 

--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -11,6 +11,7 @@ import {isDefined, mergeDeep} from "./util";
 
 export const USE_STORE = new InjectionToken<string>('USE_STORE');
 export const USE_DEFAULT_LANG = new InjectionToken<string>('USE_DEFAULT_LANG');
+export const DEFAULT_LANGUAGE = new InjectionToken<string>('DEFAULT_LANGUAGE');
 export const USE_EXTEND = new InjectionToken<string>('USE_EXTEND');
 
 export interface TranslationChangeEvent {
@@ -144,8 +145,10 @@ export class TranslateService {
    * @param compiler An instance of the compiler currently used
    * @param parser An instance of the parser currently used
    * @param missingTranslationHandler A handler for missing translations.
-   * @param isolate whether this service should use the store or not
    * @param useDefaultLang whether we should use default language translation when current language translation is missing.
+   * @param isolate whether this service should use the store or not
+   * @param extend To make a child module extend (and use) translations from parent modules.
+   * @param defaultLanguage Set the default language using configuration
    */
   constructor(public store: TranslateStore,
               public currentLoader: TranslateLoader,
@@ -154,7 +157,12 @@ export class TranslateService {
               public missingTranslationHandler: MissingTranslationHandler,
               @Inject(USE_DEFAULT_LANG) private useDefaultLang: boolean = true,
               @Inject(USE_STORE) private isolate: boolean = false,
-              @Inject(USE_EXTEND) private extend: boolean = false) {
+              @Inject(USE_EXTEND) private extend: boolean = false,
+              @Inject(DEFAULT_LANGUAGE) defaultLanguage: string) {
+    /** set the default language from configuration */
+    if (defaultLanguage) {
+      this.setDefaultLang(defaultLanguage);
+    }
   }
 
   /**

--- a/projects/ngx-translate/core/src/public_api.ts
+++ b/projects/ngx-translate/core/src/public_api.ts
@@ -1,15 +1,12 @@
 import {NgModule, ModuleWithProviders, Provider} from "@angular/core";
 import {TranslateLoader, TranslateFakeLoader} from "./lib/translate.loader";
-import {TranslateService} from "./lib/translate.service";
 import {MissingTranslationHandler, FakeMissingTranslationHandler} from "./lib/missing-translation-handler";
 import {TranslateParser, TranslateDefaultParser} from "./lib/translate.parser";
 import {TranslateCompiler, TranslateFakeCompiler} from "./lib/translate.compiler";
 import {TranslateDirective} from "./lib/translate.directive";
 import {TranslatePipe} from "./lib/translate.pipe";
 import {TranslateStore} from "./lib/translate.store";
-import {USE_STORE} from "./lib/translate.service";
-import {USE_EXTEND} from "./lib/translate.service";
-import {USE_DEFAULT_LANG} from "./lib/translate.service";
+import {USE_DEFAULT_LANG, DEFAULT_LANGUAGE, USE_STORE, TranslateService, USE_EXTEND} from "./lib/translate.service";
 
 export * from "./lib/translate.loader";
 export * from "./lib/translate.service";
@@ -30,6 +27,7 @@ export interface TranslateModuleConfig {
   // extends translations for a given language instead of ignoring them if present
   extend?: boolean;
   useDefaultLang?: boolean;
+  defaultLanguage?: string;
 }
 
 @NgModule({
@@ -58,6 +56,7 @@ export class TranslateModule {
         {provide: USE_STORE, useValue: config.isolate},
         {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
         {provide: USE_EXTEND, useValue: config.extend},
+        {provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage},
         TranslateService
       ]
     };
@@ -77,6 +76,7 @@ export class TranslateModule {
         {provide: USE_STORE, useValue: config.isolate},
         {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
         {provide: USE_EXTEND, useValue: config.extend},
+        {provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage},
         TranslateService
       ]
     };


### PR DESCRIPTION
- Default language option added for specifying the language at the time of defining the configuration in `forRoot` or `forChild` method. 

- Now user don't need to explicitly calls the `setRootLanguage` method for defining the default language at the initial time.

- Code formatted.

- Example added for `defaultLanguage`.