### PR TITLE
 Fix translationDirective ko after lang change

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -79,10 +79,10 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
           let trimmedContent = content.trim();
           if (trimmedContent.length) {
             // we want to use the content as a key, not the translation value
-            if (content !== node.currentValue) {
+            if (!node.currentValue || trimmedContent !== node.currentValue.trim()) {
               key = trimmedContent;
               // the content was changed from the user, we'll use it as a reference if needed
-              node.originalContent = this.getContent(node);
+              node.originalContent = content;
             } else if (node.originalContent && forceUpdate) { // the content seems ok, but the lang has changed
               node.lastKey = null;
               // the current content is the translation, not the key, use the last real content as key


### PR DESCRIPTION
When TranslateDirective is loaded before translations and translation is then updated through onTranslation callback, the key might be overridden with translated value and keep the value from being updated in case of future lang change. In the onTranslation callback, the node.currentValue is initialized directly from translation value and later compared from untrimmed node content (this.getContent(node)) which might contains line breaks and spaces. The fix consists in using only trimmed values to check for key update.