### PR TITLE
Translation issue on param changes fixed for translateDirective

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -79,10 +79,10 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
           let trimmedContent = content.trim();
           if (trimmedContent.length) {
             // we want to use the content as a key, not the translation value
-            if (content !== node.currentValue) {
+            if (!node.currentValue || trimmedContent !== node.currentValue.trim()) {
               key = trimmedContent;
               // the content was changed from the user, we'll use it as a reference if needed
-              node.originalContent = this.getContent(node);
+              node.originalContent = content;
             } else if (node.originalContent && forceUpdate) { // the content seems ok, but the lang has changed
               node.lastKey = null;
               // the current content is the translation, not the key, use the last real content as key


### PR DESCRIPTION
The issue where the param changes but translation is not update has been fixed. 
Issue description:
 To reproduce use following example 
`<span translate [translateParams]="{count: counter}">
      HOME.COUNT
  </span>`
 And change `counter` value with javascript code, you will see the counter value remains the initial one.