### PR TITLE
refactor: RxJS chains

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -1,5 +1,5 @@
 import {AfterViewChecked, ChangeDetectorRef, Directive, ElementRef, Input, OnDestroy} from '@angular/core';
-import {Subscription} from 'rxjs';
+import {Subscription, isObservable} from 'rxjs';
 import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
 import {equals, isDefined} from './util';
 
@@ -118,7 +118,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
 
       if (isDefined(translations)) {
         let res = this.translateService.getParsedResult(translations, key, this.currentParams);
-        if (typeof res.subscribe === "function") {
+        if (isObservable(res)) {
           res.subscribe(onTranslation);
         } else {
           onTranslation(res);

--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -1,4 +1,5 @@
 import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform} from '@angular/core';
+import {isObservable} from 'rxjs';
 import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
 import {equals, isDefined} from './util';
 
@@ -26,7 +27,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     };
     if (translations) {
       let res = this.translate.getParsedResult(translations, key, interpolateParams);
-      if (typeof res.subscribe === 'function') {
+      if (isObservable(res.subscribe)) {
         res.subscribe(onTranslation);
       } else {
         onTranslation(res);

--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -1,5 +1,5 @@
 import {EventEmitter, Inject, Injectable, InjectionToken} from "@angular/core";
-import {concat, forkJoin, isObservable, Observable, Observer, of} from "rxjs";
+import {concat, forkJoin, isObservable, Observable, of} from "rxjs";
 import {concatMap, map, shareReplay, switchMap, take} from "rxjs/operators";
 import {MissingTranslationHandler, MissingTranslationHandlerParams} from "./missing-translation-handler";
 import {TranslateCompiler} from "./translate.compiler";

--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -1,6 +1,6 @@
 import {EventEmitter, Inject, Injectable, InjectionToken} from "@angular/core";
-import {concat, merge, Observable, Observer, of} from "rxjs";
-import {map, share, switchMap, take, toArray} from "rxjs/operators";
+import {concat, forkJoin, isObservable, Observable, Observer, of} from "rxjs";
+import {concatMap, map, shareReplay, switchMap, take} from "rxjs/operators";
 import {MissingTranslationHandler, MissingTranslationHandlerParams} from "./missing-translation-handler";
 import {TranslateCompiler} from "./translate.compiler";
 import {TranslateLoader} from "./translate.loader";
@@ -238,20 +238,27 @@ export class TranslateService {
    */
   public getTranslation(lang: string): Observable<any> {
     this.pending = true;
-    const loadingTranslations = this.currentLoader.getTranslation(lang).pipe(share());
-    this.loadingTranslations = loadingTranslations.pipe(
+    const loadingTranslations = this.currentLoader.getTranslation(lang).pipe(
+      shareReplay(1),
       take(1),
+    );
+
+    this.loadingTranslations = loadingTranslations.pipe(
       map((res: Object) => this.compiler.compileTranslations(res, lang)),
-      share()
+      shareReplay(1),
+      take(1),
     );
 
     this.loadingTranslations
-      .subscribe((res: Object) => {
-        this.translations[lang] = res;
-        this.updateLangs();
-        this.pending = false;
-      }, (err: any) => {
-        this.pending = false;
+      .subscribe({
+        next: (res: Object) => {
+          this.translations[lang] = res;
+          this.updateLangs();
+          this.pending = false;
+        },
+        error: (err: any) => {
+          this.pending = false;
+        }
       });
 
     return loadingTranslations;
@@ -308,22 +315,13 @@ export class TranslateService {
         observables: boolean = false;
       for (let k of key) {
         result[k] = this.getParsedResult(translations, k, interpolateParams);
-        if (typeof result[k].subscribe === "function") {
+        if (isObservable(result[k])) {
           observables = true;
         }
       }
       if (observables) {
-        let mergedObs: Observable<string>;
-        for (let k of key) {
-          let obs = typeof result[k].subscribe === "function" ? result[k] : of(result[k] as string);
-          if (typeof mergedObs === "undefined") {
-            mergedObs = obs;
-          } else {
-            mergedObs = merge(mergedObs, obs);
-          }
-        }
-        return mergedObs.pipe(
-          toArray(),
+        const sources = key.map(k => isObservable(result[k]) ? result[k] : of(result[k] as string));
+        return forkJoin(sources).pipe(
           map((arr: Array<string>) => {
             let obj: any = {};
             arr.forEach((value: string, index: number) => {
@@ -365,30 +363,15 @@ export class TranslateService {
     }
     // check if we are loading a new translation to use
     if (this.pending) {
-      return Observable.create((observer: Observer<string>) => {
-        let onComplete = (res: string) => {
-          observer.next(res);
-          observer.complete();
-        };
-        let onError = (err: any) => {
-          observer.error(err);
-        };
-        this.loadingTranslations.subscribe((res: any) => {
+      return this.loadingTranslations.pipe(
+        concatMap((res: any) => {
           res = this.getParsedResult(res, key, interpolateParams);
-          if (typeof res.subscribe === "function") {
-            res.subscribe(onComplete, onError);
-          } else {
-            onComplete(res);
-          }
-        }, onError);
-      });
+          return isObservable(res) ? res : of(res);
+        }),
+      );
     } else {
       let res = this.getParsedResult(this.translations[this.currentLang], key, interpolateParams);
-      if (typeof res.subscribe === "function") {
-        return res;
-      } else {
-        return of(res);
-      }
+      return isObservable(res) ? res : of(res);
     }
   }
 
@@ -407,11 +390,7 @@ export class TranslateService {
       this.onLangChange.pipe(
         switchMap((event: LangChangeEvent) => {
           const res = this.getParsedResult(event.translations, key, interpolateParams);
-          if (typeof res.subscribe === "function") {
-            return res;
-          } else {
-            return of(res);
-          }
+          return isObservable(res) ? res : of(res);
         })
       ));
   }
@@ -426,7 +405,7 @@ export class TranslateService {
     }
 
     let res = this.getParsedResult(this.translations[this.currentLang], key, interpolateParams);
-    if (typeof res.subscribe !== "undefined") {
+    if (isObservable(res)) {
       if (key instanceof Array) {
         let obj: any = {};
         key.forEach((value: string, index: number) => {

--- a/projects/ngx-translate/core/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.service.spec.ts
@@ -1,5 +1,5 @@
 import {fakeAsync, TestBed, tick} from "@angular/core/testing";
-import { defer, Observable, of, timer, zip } from 'rxjs';
+import {Observable, of, timer, zip, defer} from "rxjs";
 import {mapTo, take, toArray} from 'rxjs/operators';
 import {LangChangeEvent, TranslateLoader, TranslateModule, TranslateService, TranslationChangeEvent} from '../src/public_api';
 

--- a/projects/ngx-translate/core/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.service.spec.ts
@@ -1,5 +1,5 @@
 import {fakeAsync, TestBed, tick} from "@angular/core/testing";
-import {Observable, of, timer, zip} from "rxjs";
+import { defer, Observable, of, timer, zip } from 'rxjs';
 import {mapTo, take, toArray} from 'rxjs/operators';
 import {LangChangeEvent, TranslateLoader, TranslateModule, TranslateService, TranslationChangeEvent} from '../src/public_api';
 
@@ -393,7 +393,7 @@ describe('TranslateService', () => {
     expect(typeof browserCultureLand === 'string').toBeTruthy();
   });
 
-  it('should not make duplicate requests', fakeAsync(() => {
+  it('should not make duplicate getTranslation calls', fakeAsync(() => {
     let getTranslationCalls = 0;
     spyOn(translate.currentLoader, 'getTranslation').and.callFake(() => {
       getTranslationCalls += 1;
@@ -406,6 +406,22 @@ describe('TranslateService', () => {
 
     expect(getTranslationCalls).toEqual(1);
   }));
+
+  it('should subscribe to the loader just once', () => {
+    let subscriptions = 0;
+    spyOn(translate.currentLoader, 'getTranslation').and.callFake(() => {
+      return defer(() => {
+        subscriptions++;
+        return of(translations);
+      });
+    });
+    translate.use('en');
+    translate.use('en');
+    translate.use('en').subscribe();
+    translate.use('en').subscribe();
+
+    expect(subscriptions).toEqual(1);
+  });
 
   it('should compile translations only once, even when subscribing to translations while translations are loading', fakeAsync(() => {
     spyOn(translate.currentLoader, 'getTranslation').and.callFake(() => {


### PR DESCRIPTION
I went through the code base and refactored some RxJS usage where I thought it could be improved or where it was using old and deprecated notations. I'm adding comments where it's not obvious what I did there.

In general there are two larger changes:
- Replacing deprecated `subscribe(v => void, func)` calls with `subscribe({ next: v => void, error: e => void})` https://github.com/ReactiveX/rxjs/issues/4159.
- Replacing Observable checks like `typeof res.subscribe === 'function'` with `isObservable(res.subscribe)`.

All existing tests were passing I just added one more additional test for some sync behavior.