### PR TITLE
fix(directive): untranslated keys return the last cumputed value

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -86,7 +86,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
               // we want to use the content as a key, not the translation value
               key = trimmedContent;
               // the content was changed from the user, we'll use it as a reference if needed
-              node.originalContent = node.originalContent || content;
+              node.originalContent = content || node.originalContent;
             }
           }
         }


### PR DESCRIPTION
This pull request is proposal to fix the following issue
https://github.com/ngx-translate/core/issues/1164

This produce the same behavior as in v11.0.1, the directive use the current text/value computed by angular change detection when the keys has neither an entry in the translation file for this language, nor in the default language translation file