### PR TITLE
Update TranslatePipe to working with Angular 9

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -22,6 +22,8 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
 
   updateValue(key: string, interpolateParams?: Object, translations?: any): void {
     let onTranslation = (res: string) => {
+      if (res === key) { return; }
+
       this.value = res !== undefined ? res : key;
       this.lastKey = key;
       this._ref.markForCheck();


### PR DESCRIPTION
I know it looks like hack but it works for now.
By some reasons `updateValue()` is called twice and at second time the `this.translate.get(key, interpolateParams)` returns the key of pipe instead of the real result from previous call.