### PR TITLE
chore(README): missing @Injectable in MissingTranslationHandler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,8 +466,10 @@ You can use `useDefaultLang` to decide whether default language string should be
 Create a Missing Translation Handler
 
 ```ts
+import {Injectable} from "@angular/core";
 import {MissingTranslationHandler, MissingTranslationHandlerParams} from '@ngx-translate/core';
 
+@Injectable()
 export class MyMissingTranslationHandler implements MissingTranslationHandler {
     handle(params: MissingTranslationHandlerParams) {
         return 'some value';


### PR DESCRIPTION
Pretty much as commit message. The example is missing the @Injectable() decorator.