### PR TITLE
 fix(directive): translate by attribute (not binding) with translation key as value

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate.directive.ts
@@ -3,6 +3,29 @@ import {Subscription, isObservable} from 'rxjs';
 import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
 import {equals, isDefined} from './util';
 
+function isTextNode(node: Node): boolean {
+  return node.nodeType === 3;
+}
+
+function getContent(node: any): string {
+  return isDefined(node.textContent) ? node.textContent : node.data;
+}
+
+function setContent(node: any, content: string): void {
+  if (isDefined(node.textContent)) {
+    node.textContent = content;
+  } else {
+    node.data = content;
+  }
+}
+
+interface NodeExt extends Node {
+  lookupKey: string;
+  lastKey: string;
+  currentValue: string;
+  originalContent: string;
+}
+
 @Directive({
   selector: '[translate],[ngx-translate]'
 })
@@ -17,14 +40,12 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
   @Input() set translate(key: string) {
     if (key) {
       this.key = key;
-      this.checkNodes();
     }
   }
 
   @Input() set translateParams(params: any) {
     if (!equals(this.currentParams, params)) {
       this.currentParams = params;
-      this.checkNodes(true);
     }
   }
 
@@ -59,93 +80,87 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
 
   checkNodes(forceUpdate = false, translations?: any) {
     let nodes: NodeList = this.element.nativeElement.childNodes;
-    // if the element is empty
     if (!nodes.length) {
-      // we add the key as content
-      this.setContent(this.element.nativeElement, this.key);
+      setContent(this.element.nativeElement, this.key);  // we add the key as content
       nodes = this.element.nativeElement.childNodes;
     }
+
     for (let i = 0; i < nodes.length; ++i) {
-      let node: any = nodes[i];
-      if (node.nodeType === 3) { // node type 3 is a text node
-        let key: string;
-        if (forceUpdate) {
-          node.lastKey = null;
-        }
-        if(isDefined(node.lookupKey)) {
-          key = node.lookupKey;
-        } else if (this.key) {
-          key = this.key;
-        } else {
-          let content = this.getContent(node);
-          let trimmedContent = content.trim();
-          if (trimmedContent.length) {
-            node.lookupKey = trimmedContent;
-            // we want to use the content as a key, not the translation value
-            if (content !== node.currentValue) {
-              key = trimmedContent;
-              // the content was changed from the user, we'll use it as a reference if needed
-              node.originalContent = content || node.originalContent;
-            } else if (node.originalContent) { // the content seems ok, but the lang has changed
-              // the current content is the translation, not the key, use the last real content as key
-              key = node.originalContent.trim();
-            } else if (content !== node.currentValue) {
-              // we want to use the content as a key, not the translation value
-              key = trimmedContent;
-              // the content was changed from the user, we'll use it as a reference if needed
-              node.originalContent = content || node.originalContent;
-            }
+      let node: NodeExt = nodes[i] as NodeExt;
+
+      if (!isTextNode(node)) {
+        continue;
+      }
+
+      if (forceUpdate) {
+        node.lastKey = null;
+      }
+
+      let key: string;
+
+      if (isDefined(node.lookupKey)) {
+        key = node.lookupKey;
+      } else if (this.key) {
+        key = this.key;
+      } else {
+        const content = getContent(node);
+        const trimmedContent = content.trim();
+
+        if (trimmedContent.length) {
+          node.lookupKey = trimmedContent;
+          // we want to use the content as a key, not the translation value
+          if (content !== node.currentValue) {
+            key = trimmedContent;
+            // the content was changed from the user, we'll use it as a reference if needed
+            node.originalContent = content || node.originalContent;
+          } else if (node.originalContent) { // the content seems ok, but the lang has changed
+            // the current content is the translation, not the key, use the last real content as key
+            key = node.originalContent.trim();
           }
         }
-        this.updateValue(key, node, translations);
       }
+
+      this.updateValue(key, node, translations);
     }
   }
 
   updateValue(key: string, node: any, translations: any) {
-    if (key) {
-      if (node.lastKey === key && this.lastParams === this.currentParams) {
-        return;
-      }
+    if (!key || node.lastKey === key && this.lastParams === this.currentParams) {
+      return;
+    }
 
-      this.lastParams = this.currentParams;
+    this.lastParams = this.currentParams;
 
-      let onTranslation = (res: string) => {
-        if (res !== key) {
-          node.lastKey = key;
-        }
-        if (!node.originalContent) {
-          node.originalContent = this.getContent(node);
-        }
-        node.currentValue = isDefined(res) ? res : (node.originalContent || key);
-        // we replace in the original content to preserve spaces that we might have trimmed
-        this.setContent(node, this.key ? node.currentValue : node.originalContent.replace(key, node.currentValue));
-        this._ref.markForCheck();
-      };
+    const onTranslation = (r: string) => this.onTranslation(key, r, node);
 
-      if (isDefined(translations)) {
-        let res = this.translateService.getParsedResult(translations, key, this.currentParams);
-        if (isObservable(res)) {
-          res.subscribe(onTranslation);
-        } else {
-          onTranslation(res);
-        }
+    if (isDefined(translations)) {
+      const res = this.translateService.getParsedResult(translations, key, this.currentParams);
+      if (isObservable(res)) {
+        res.subscribe(onTranslation);
       } else {
-        this.translateService.get(key, this.currentParams).subscribe(onTranslation);
+        onTranslation(res);
       }
-    }
-  }
-
-  getContent(node: any): string {
-    return isDefined(node.textContent) ? node.textContent : node.data;
-  }
-
-  setContent(node: any, content: string): void {
-    if (isDefined(node.textContent)) {
-      node.textContent = content;
     } else {
-      node.data = content;
+      this.translateService.get(key, this.currentParams).subscribe(onTranslation);
     }
+  }
+
+  onTranslation(key: string, res: string, node: any) {
+    if (res !== key) {
+      node.lastKey = key;
+    }
+
+    if (!node.originalContent) {
+      node.originalContent = getContent(node);
+    }
+
+    node.currentValue = isDefined(res) ? res : (node.originalContent || key);
+    // we replace in the original content to preserve spaces that we might have trimmed
+    const content = this.key
+      ? node.currentValue
+      : node.originalContent.replace(key, node.currentValue);
+    setContent(node, content);
+    this._ref.markForCheck();
   }
 
   ngOnDestroy() {

--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -1,10 +1,8 @@
-import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform} from '@angular/core';
-import {isObservable} from 'rxjs';
-import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
+import {ChangeDetectorRef, OnDestroy, Pipe, PipeTransform} from '@angular/core';
+import {isObservable, Subscription} from 'rxjs';
+import {LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
 import {equals, isDefined} from './util';
-import { Subscription } from 'rxjs';
 
-@Injectable()
 @Pipe({
   name: 'translate',
   pure: false // required to update the value when the promise is resolved

--- a/projects/ngx-translate/core/tests/translate.directive.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.directive.spec.ts
@@ -1,8 +1,7 @@
-import {ChangeDetectionStrategy, Component, ElementRef, Injectable, ViewChild, ViewContainerRef} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ElementRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TranslateModule, TranslateService} from '../src/public_api';
 
-@Injectable()
 @Component({
   selector: 'hmx-app',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -10,6 +9,8 @@ import {TranslateModule, TranslateService} from '../src/public_api';
     <div #noKey translate>TEST</div>
     <div #contentAsKey translate>TEST.VALUE</div>
     <div #withKey [translate]="'TEST'">Some init content</div>
+    <div #attributeWithValue translate="TEST">Should be changed</div>
+    <div #attributeWithValueAndParams translate="TEST" [translateParams]="{value: 'great'}">Should be changed</div>
     <div #noContent [translate]="'TEST'"></div>
     <div #withOtherElements translate>TEST1 <span>Hey</span> TEST2</div>
     <div #withParams [translate]="'TEST'" [translateParams]="value">Some init content</div>
@@ -26,6 +27,8 @@ class App {
   @ViewChild('noKey', {static: true}) noKey: ElementRef;
   @ViewChild('contentAsKey', {static: true}) contentAsKey: ElementRef;
   @ViewChild('withKey', {static: true}) withKey: ElementRef;
+  @ViewChild('attributeWithValue', {static: true}) attributeWithValue: ElementRef;
+  @ViewChild('attributeWithValueAndParams', {static: true}) attributeWithValueAndParams: ElementRef;
   @ViewChild('withOtherElements', {static: true}) withOtherElements: ElementRef;
   @ViewChild('withParams', {static: true}) withParams: ElementRef;
   @ViewChild('withParamsNoKey', {static: true}) withParamsNoKey: ElementRef;
@@ -88,6 +91,24 @@ describe('TranslateDirective', () => {
     translate.use('en');
 
     expect(fixture.componentInstance.withKey.nativeElement.innerHTML).toEqual('This is a test');
+  });
+
+  it('should translate a string using HTML attribute with value', () => {
+    expect(fixture.componentInstance.attributeWithValue.nativeElement.innerHTML).toEqual('TEST');
+
+    translate.setTranslation('en', {"TEST": "This is a test"});
+    translate.use('en');
+
+    expect(fixture.componentInstance.attributeWithValue.nativeElement.innerHTML).toEqual('This is a test');
+  });
+
+  it('should translate a string using HTML attribute with value and with params', () => {
+    expect(fixture.componentInstance.attributeWithValueAndParams.nativeElement.innerHTML).toEqual('TEST');
+
+    translate.setTranslation('en', {"TEST": "It is {{value}}"});
+    translate.use('en');
+
+    expect(fixture.componentInstance.attributeWithValueAndParams.nativeElement.innerHTML).toEqual('It is great');
   });
 
   it('should translate first child strings with elements in the middle', () => {

--- a/projects/ngx-translate/core/tests/translate.pipe.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.pipe.spec.ts
@@ -1,7 +1,14 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injectable, ViewContainerRef} from "@angular/core";
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewContainerRef} from "@angular/core";
 import {TestBed} from "@angular/core/testing";
 import {Observable, of} from "rxjs";
-import {DefaultLangChangeEvent, LangChangeEvent, TranslateLoader, TranslateModule, TranslatePipe, TranslateService} from "../src/public_api";
+import {
+  DefaultLangChangeEvent,
+  LangChangeEvent,
+  TranslateLoader,
+  TranslateModule,
+  TranslatePipe,
+  TranslateService
+} from "../src/public_api";
 
 class FakeChangeDetectorRef extends ChangeDetectorRef {
   markForCheck(): void {
@@ -20,7 +27,6 @@ class FakeChangeDetectorRef extends ChangeDetectorRef {
   }
 }
 
-@Injectable()
 @Component({
   selector: 'hmx-app',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Fix for angular 9 & 10

This PR fixes the behaiviour of `TranslateDirective` when it is used as a simple attribute `translate` (not attribute binding `[translate]`) with value and translated element already contains some text. Example:

```html
<div #attributeWithValue translate="TEST">Should be changed</div>
<div #attributeWithValueAndParams translate="TEST" [translateParams]="{value: 'great'}">Should be changed</div>
```

Currently (without this fix) this code will result in text translated twice. If value for `'TEST'` in english is "This is a test", after directive is executed, value of **#attributeWithValue** will be "This is a testThis is a test".

There was no such problem while using ng-translate with Angular 8. But since Angular 9 it appeared.

This PR also contains some refactorings.