### PR TITLE
feat(core) - adds *translateContext & *translateNamespace directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,35 +7,37 @@ Simple example using ngx-translate: https://stackblitz.com/github/ngx-translate/
 Get the complete changelog here: https://github.com/ngx-translate/core/releases
 
 ## Table of Contents
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Import the TranslateModule](#1-import-the-translatemodule)
-    * [SharedModule](#sharedmodule)
-    * [Lazy loaded modules](#lazy-loaded-modules)
-    * [Configuration](#configuration)
-    * [AoT](#aot)
-  * [Define the default language for the application](#2-define-the-default-language-for-the-application)
-  * [Init the TranslateService for your application](#3-init-the-translateservice-for-your-application)
-  * [Define the translations](#4-define-the-translations)
-  * [Use the service, the pipe or the directive](#5-use-the-service-the-pipe-or-the-directive)
-  * [Use HTML tags](#6-use-html-tags)
-* [API](#api)
-  * [TranslateService](#translateservice)
-    * [Properties](#properties)
-    * [Methods](#methods)
-    * [Write & use your own loader](#write--use-your-own-loader)
-      * [Example](#example)
-    * [How to use a compiler to preprocess translation values](#how-to-use-a-compiler-to-preprocess-translation-values)
-    * [How to handle missing translations](#how-to-handle-missing-translations)
-      * [Example](#example-1)
-  * [Parser](#parser)
-    * [Methods](#methods)
-* [FAQ](#faq)
-  * [I'm getting an error `npm ERR! peerinvalid Peer [...]`](#im-getting-an-error-npm-err-peerinvalid-peer-)
-* [Plugins](#plugins)
-* [Editors](#editors)
-* [Additional Framework Support](#additional-framework-support)
 
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Import the TranslateModule](#1-import-the-translatemodule)
+    - [SharedModule](#sharedmodule)
+    - [Lazy loaded modules](#lazy-loaded-modules)
+    - [Configuration](#configuration)
+    - [AoT](#aot)
+  - [Define the default language for the application](#2-define-the-default-language-for-the-application)
+  - [Init the TranslateService for your application](#3-init-the-translateservice-for-your-application)
+  - [Define the translations](#4-define-the-translations)
+  - [Use the service, the pipe or the directive](#5-use-the-service-the-pipe-or-the-directive)
+  - [Use HTML tags](#6-use-html-tags)
+  - [Use translateNamespace directive](#7-use-translate-namespace)
+  - [Use translateContext directive](#8-use-translate-context)
+- [API](#api)
+  - [TranslateService](#translateservice)
+    - [Properties](#properties)
+    - [Methods](#methods)
+    - [Write & use your own loader](#write--use-your-own-loader)
+      - [Example](#example)
+    - [How to use a compiler to preprocess translation values](#how-to-use-a-compiler-to-preprocess-translation-values)
+    - [How to handle missing translations](#how-to-handle-missing-translations)
+      - [Example](#example-1)
+  - [Parser](#parser)
+    - [Methods](#methods)
+- [FAQ](#faq)
+  - [I'm getting an error `npm ERR! peerinvalid Peer [...]`](#im-getting-an-error-npm-err-peerinvalid-peer-)
+- [Plugins](#plugins)
+- [Editors](#editors)
+- [Additional Framework Support](#additional-framework-support)
 
 ## Installation
 
@@ -47,18 +49,17 @@ npm install @ngx-translate/core --save
 
 Choose the version corresponding to your Angular version:
 
- Angular       | @ngx-translate/core | @ngx-translate/http-loader
- ------------- | ------------------- | --------------------------
- 13 (ivy only) | 14.x+               | 7.x+
- 10/11/12/13   | 13.x+               | 6.x+
- 9             | 12.x+               | 5.x+
- 8             | 12.x+               | 4.x+
- 7             | 11.x+               | 4.x+
- 6             | 10.x                | 3.x
- 5             | 8.x to 9.x          | 1.x to 2.x
- 4.3           | 7.x or less         | 1.x to 2.x
- 2 to 4.2.x    | 7.x or less         | 0.x
-
+| Angular       | @ngx-translate/core | @ngx-translate/http-loader |
+| ------------- | ------------------- | -------------------------- |
+| 13 (ivy only) | 14.x+               | 7.x+                       |
+| 10/11/12/13   | 13.x+               | 6.x+                       |
+| 9             | 12.x+               | 5.x+                       |
+| 8             | 12.x+               | 4.x+                       |
+| 7             | 11.x+               | 4.x+                       |
+| 6             | 10.x                | 3.x                        |
+| 5             | 8.x to 9.x          | 1.x to 2.x                 |
+| 4.3           | 7.x or less         | 1.x to 2.x                 |
+| 2 to 4.2.x    | 7.x or less         | 0.x                        |
 
 ## Usage
 
@@ -71,18 +72,15 @@ Make sure you only call this method in the root module of your application, most
 This method allows you to configure the `TranslateModule` by specifying a loader, a parser and/or a missing translations handler.
 
 ```ts
-import {BrowserModule} from '@angular/platform-browser';
-import {NgModule} from '@angular/core';
-import {TranslateModule} from '@ngx-translate/core';
+import { BrowserModule } from "@angular/platform-browser";
+import { NgModule } from "@angular/core";
+import { TranslateModule } from "@ngx-translate/core";
 
 @NgModule({
-    imports: [
-        BrowserModule,
-        TranslateModule.forRoot()
-    ],
-    bootstrap: [AppComponent]
+  imports: [BrowserModule, TranslateModule.forRoot()],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
 ##### SharedModule
@@ -92,12 +90,9 @@ you can export the `TranslateModule` to make sure you don't have to import it in
 
 ```ts
 @NgModule({
-    exports: [
-        CommonModule,
-        TranslateModule
-    ]
+  exports: [CommonModule, TranslateModule],
 })
-export class SharedModule { }
+export class SharedModule {}
 ```
 
 > Note: Never call a `forRoot` static method in the `SharedModule`. You might end up with different instances of the service in your injector tree. But you can use `forChild` if necessary.
@@ -116,17 +111,20 @@ Otherwise, by default, it will share its data with other instances of the servic
 
 ```ts
 @NgModule({
-    imports: [
-        TranslateModule.forChild({
-            loader: {provide: TranslateLoader, useClass: CustomLoader},
-            compiler: {provide: TranslateCompiler, useClass: CustomCompiler},
-            parser: {provide: TranslateParser, useClass: CustomParser},
-            missingTranslationHandler: {provide: MissingTranslationHandler, useClass: CustomHandler},
-            isolate: true
-        })
-    ]
+  imports: [
+    TranslateModule.forChild({
+      loader: { provide: TranslateLoader, useClass: CustomLoader },
+      compiler: { provide: TranslateCompiler, useClass: CustomCompiler },
+      parser: { provide: TranslateParser, useClass: CustomParser },
+      missingTranslationHandler: {
+        provide: MissingTranslationHandler,
+        useClass: CustomHandler,
+      },
+      isolate: true,
+    }),
+  ],
 })
-export class LazyLoadedModule { }
+export class LazyLoadedModule {}
 ```
 
 ##### Configuration
@@ -146,33 +144,33 @@ Once you've decided which loader to use, you have to setup the `TranslateModule`
 Here is how you would use the `TranslateHttpLoader` to load translations from "/assets/i18n/[lang].json" (`[lang]` is the lang that you're using, for english it could be `en`):
 
 ```ts
-import {NgModule} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
-import {HttpClientModule, HttpClient} from '@angular/common/http';
-import {TranslateModule, TranslateLoader} from '@ngx-translate/core';
-import {TranslateHttpLoader} from '@ngx-translate/http-loader';
-import {AppComponent} from './app';
+import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+import { HttpClientModule, HttpClient } from "@angular/common/http";
+import { TranslateModule, TranslateLoader } from "@ngx-translate/core";
+import { TranslateHttpLoader } from "@ngx-translate/http-loader";
+import { AppComponent } from "./app";
 
 // AoT requires an exported function for factories
 export function HttpLoaderFactory(http: HttpClient) {
-    return new TranslateHttpLoader(http);
+  return new TranslateHttpLoader(http);
 }
 
 @NgModule({
-    imports: [
-        BrowserModule,
-        HttpClientModule,
-        TranslateModule.forRoot({
-            loader: {
-                provide: TranslateLoader,
-                useFactory: HttpLoaderFactory,
-                deps: [HttpClient]
-            }
-        })
-    ],
-    bootstrap: [AppComponent]
+  imports: [
+    BrowserModule,
+    HttpClientModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: HttpLoaderFactory,
+        deps: [HttpClient],
+      },
+    }),
+  ],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
 ##### AoT
@@ -181,66 +179,62 @@ If you want to configure a custom `TranslateLoader` while using [AoT compilation
 
 ```ts
 export function createTranslateLoader(http: HttpClient) {
-    return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, "./assets/i18n/", ".json");
 }
 
 @NgModule({
-    imports: [
-        BrowserModule,
-        HttpClientModule,
-        TranslateModule.forRoot({
-            loader: {
-                provide: TranslateLoader,
-                useFactory: (createTranslateLoader),
-                deps: [HttpClient]
-            }
-        })
-    ],
-    bootstrap: [AppComponent]
+  imports: [
+    BrowserModule,
+    HttpClientModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: createTranslateLoader,
+        deps: [HttpClient],
+      },
+    }),
+  ],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
 #### 2. Define the `default language` for the application
 
 ```ts
 @NgModule({
-    imports: [
-        BrowserModule,
-        TranslateModule.forRoot({
-            defaultLanguage: 'en'
-        })
-    ],
-    providers: [
-
-    ],
-    bootstrap: [AppComponent]
+  imports: [
+    BrowserModule,
+    TranslateModule.forRoot({
+      defaultLanguage: "en",
+    }),
+  ],
+  providers: [],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
 #### 3. Init the `TranslateService` for your application:
 
 ```ts
-import {Component} from '@angular/core';
-import {TranslateService} from '@ngx-translate/core';
+import { Component } from "@angular/core";
+import { TranslateService } from "@ngx-translate/core";
 
 @Component({
-    selector: 'app',
-    template: `
-        <div>{{ 'HELLO' | translate:param }}</div>
-    `
+  selector: "app",
+  template: ` <div>{{ "HELLO" | translate: param }}</div> `,
 })
 export class AppComponent {
-    param = {value: 'world'};
+  param = { value: "world" };
 
-    constructor(translate: TranslateService) {
-        // this language will be used as a fallback when a translation isn't found in the current language
-        translate.setDefaultLang('en');
+  constructor(translate: TranslateService) {
+    // this language will be used as a fallback when a translation isn't found in the current language
+    translate.setDefaultLang("en");
 
-         // the lang to use, if the lang isn't available, it will use the current loader to get them
-        translate.use('en');
-    }
+    // the lang to use, if the lang isn't available, it will use the current loader to get them
+    translate.use("en");
+  }
 }
 ```
 
@@ -250,15 +244,15 @@ Once you've imported the `TranslateModule`, you can put your translations in a j
 
 ```json
 {
-    "HELLO": "hello {{value}}"
+  "HELLO": "hello {{value}}"
 }
 ```
 
 You can also define your translations manually with `setTranslation`.
 
 ```ts
-translate.setTranslation('en', {
-    HELLO: 'hello {{value}}'
+translate.setTranslation("en", {
+  HELLO: "hello {{value}}",
 });
 ```
 
@@ -266,9 +260,9 @@ The `TranslateParser` understands nested JSON objects. This means that you can h
 
 ```json
 {
-    "HOME": {
-        "HELLO": "hello {{value}}"
-    }
+  "HOME": {
+    "HELLO": "hello {{value}}"
+  }
 }
 ```
 
@@ -281,9 +275,9 @@ You can either use the `TranslateService`, the `TranslatePipe` or the `Translate
 With the **service**, it looks like this:
 
 ```ts
-translate.get('HELLO', {value: 'world'}).subscribe((res: string) => {
-    console.log(res);
-    //=> 'hello world'
+translate.get("HELLO", { value: "world" }).subscribe((res: string) => {
+  console.log(res);
+  //=> 'hello world'
 });
 ```
 
@@ -294,8 +288,9 @@ This is how you do it with the **pipe**:
 ```
 
 And in your component define `param` like this:
+
 ```ts
-param = {value: 'world'};
+param = { value: "world" };
 ```
 
 You can construct the translation keys dynamically by using simple string concatenation inside the template:
@@ -309,7 +304,7 @@ You can construct the translation keys dynamically by using simple string concat
 Where `languages` is an array member of your component:
 
 ```ts
-languages = ['EN', 'FR', 'BG'];
+languages = ["EN", "FR", "BG"];
 ```
 
 You can also use the output of the built-in pipes `uppercase` and `lowercase` in order to guarantee that your dynamically generated translation keys are either all uppercase or all lowercase. For example:
@@ -319,10 +314,11 @@ You can also use the output of the built-in pipes `uppercase` and `lowercase` in
 ```
 
 ```ts
-role = 'admin';
+role = "admin";
 ```
 
 will match the following translation:
+
 ```json
 {
   "ROLES": {
@@ -332,11 +328,13 @@ will match the following translation:
 ```
 
 This is how you use the **directive**:
+
 ```html
 <div [translate]="'HELLO'" [translateParams]="{value: 'world'}"></div>
 ```
 
 Or even simpler using the content of your element as a key:
+
 ```html
 <div translate [translateParams]="{value: 'world'}">HELLO</div>
 ```
@@ -347,7 +345,7 @@ You can easily use raw HTML tags within your translations.
 
 ```json
 {
-    "HELLO": "Welcome to my Angular application!<br><strong>This is an amazing app which uses the latest technologies!</strong>"
+  "HELLO": "Welcome to my Angular application!<br><strong>This is an amazing app which uses the latest technologies!</strong>"
 }
 ```
 
@@ -355,6 +353,85 @@ To render them, simply use the `innerHTML` attribute with the pipe on any elemen
 
 ```html
 <div [innerHTML]="'HELLO' | translate"></div>
+```
+
+#### 7. Use translate namespace:
+
+You can namespace your keys using the `*translateNamespace` structural directive
+
+```html
+<ul *translateNamespace="'somApp.pageX.contentComponent'">
+  <li translate>key1</li>
+  <li translate>key2</li>
+  <li translate>key3</li>
+</ul>
+```
+
+Would translate the `somApp.pageX.contentComponent.key1`, `somApp.pageX.contentComponent.key2` and `somApp.pageX.contentComponent.key3` keys.
+
+The namespaces directive are also stackable:
+
+```html
+// app.component.html
+<div *translateNamespace="'someApp'">
+  <router-outlet></router-outlet>
+</div>
+```
+
+```html
+// pageX.component.html
+<div *translateNamespace="'pageX'">
+  <content-component></content-component>
+</div>
+```
+
+```html
+// content.component.html
+<ul *translateNamespace="'contentComponent'">
+  <li translate>key1</li>
+  <li translate>key2</li>
+  <li translate>key3</li>
+</ul>
+```
+
+> **Note:**
+>
+> To avoid breaking changes, the translation resolution will fallback to a non namespaced key if the key isn't found in a given namespace.
+
+#### 8. Use translate context:
+
+You can use the `*translateContext` structural directive to provide the context of all child translation to avoir to repeat the translateParams directive.
+
+```json
+{
+  "person": {
+    "bio": {
+      "nameColumn": "{{firstName}} {{lastName}}",
+      "addressColumn": "{{address}} {{city}} {{state}}",
+      "age": "{{age}} years old"
+    }
+  }
+}
+```
+
+```html
+<ul *translateContext="person">
+  <li translate>person.bio.nameColumn</li>
+  <li translate>person.bio.addressColumn</li>
+  <li translate>person.bio.age</li>
+</ul>
+```
+
+The context are also stackable. Meaning that context from parent dom element will be inherited and merged with the current context.
+
+Since `*translateNamespace` and `*translateContext` are structural directives and Angular limits one structural directive per element, it is possible to provide the namespace on the `*translateContext` directive:
+
+```html
+<ul *translateContext="person; namespace: 'person.bio' ">
+  <li translate>nameColumn</li>
+  <li translate>addressColumn</li>
+  <li translate>age</li>
+</ul>
 ```
 
 ## API
@@ -367,28 +444,33 @@ To render them, simply use the `innerHTML` attribute with the pipe on any elemen
 - `currentLoader`: An instance of the loader currently used (static loader by default)
 - `onLangChange`: An EventEmitter to listen to lang change events. A `LangChangeEvent` is an object with the properties `lang: string` & `translations: any` (an object containing your translations).
 
-    example:
-    ```ts
-    onLangChange.subscribe((event: LangChangeEvent) => {
-	  // do something
-	});
-    ```
+  example:
+
+  ```ts
+  onLangChange.subscribe((event: LangChangeEvent) => {
+    // do something
+  });
+  ```
+
 - `onTranslationChange`: An EventEmitter to listen to translation change events. A `TranslationChangeEvent` is an object with the properties `lang: string` & `translations: any` (an object containing your translations).
 
-    example:
-    ```ts
-    onTranslationChange.subscribe((event: TranslationChangeEvent) => {
-	  // do something
-	});
-    ```
+  example:
+
+  ```ts
+  onTranslationChange.subscribe((event: TranslationChangeEvent) => {
+    // do something
+  });
+  ```
+
 - `onDefaultLangChange`: An EventEmitter to listen to default lang change events. A `DefaultLangChangeEvent` is an object with the properties `lang: string` & `translations: any` (an object containing your translations).
 
-    example:
-    ```ts
-    onDefaultLangChange.subscribe((event: DefaultLangChangeEvent) => {
-	  // do something
-	});
-    ```
+  example:
+
+  ```ts
+  onDefaultLangChange.subscribe((event: DefaultLangChangeEvent) => {
+    // do something
+  });
+  ```
 
 #### Methods:
 
@@ -417,9 +499,9 @@ If you want to write your own loader, you need to create a class that implements
 
 ```ts
 class CustomLoader implements TranslateLoader {
-    getTranslation(lang: string): Observable<any> {
-        return Observable.of({KEY: 'value'});
-    }
+  getTranslation(lang: string): Observable<any> {
+    return Observable.of({ KEY: "value" });
+  }
 }
 ```
 
@@ -427,16 +509,17 @@ Once you've defined your loader, you can provide it in your configuration by add
 
 ```ts
 @NgModule({
-    imports: [
-        BrowserModule,
-        TranslateModule.forRoot({
-            loader: {provide: TranslateLoader, useClass: CustomLoader}
-        })
-    ],
-    bootstrap: [AppComponent]
+  imports: [
+    BrowserModule,
+    TranslateModule.forRoot({
+      loader: { provide: TranslateLoader, useClass: CustomLoader },
+    }),
+  ],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 ```
+
 [Another custom loader example with translations stored in Firebase](FIREBASE_EXAMPLE.md)
 
 #### How to use a compiler to preprocess translation values
@@ -444,10 +527,9 @@ export class AppModule { }
 By default, translation values are added "as-is". You can configure a `compiler` that implements `TranslateCompiler` to pre-process translation values when they are added (either manually or by a loader). A compiler has the following methods:
 
 - `compile(value: string, lang: string): string | Function`: Compiles a string to a function or another string.
-- `compileTranslations(translations: any, lang: string): any`:  Compiles a (possibly nested) object of translation values to a structurally identical object of compiled translation values.
+- `compileTranslations(translations: any, lang: string): any`: Compiles a (possibly nested) object of translation values to a structurally identical object of compiled translation values.
 
 Using a compiler opens the door for powerful pre-processing of translation values. As long as the compiler outputs a compatible interpolation string or an interpolation function, arbitrary input syntax can be supported.
-
 
 #### How to handle missing translations
 
@@ -460,12 +542,15 @@ You can use `useDefaultLang` to decide whether default language string should be
 Create a Missing Translation Handler
 
 ```ts
-import {MissingTranslationHandler, MissingTranslationHandlerParams} from '@ngx-translate/core';
+import {
+  MissingTranslationHandler,
+  MissingTranslationHandlerParams,
+} from "@ngx-translate/core";
 
 export class MyMissingTranslationHandler implements MissingTranslationHandler {
-    handle(params: MissingTranslationHandlerParams) {
-        return 'some value';
-    }
+  handle(params: MissingTranslationHandlerParams) {
+    return "some value";
+  }
 }
 ```
 
@@ -473,19 +558,20 @@ Setup the Missing Translation Handler in your module import by adding it to the 
 
 ```ts
 @NgModule({
-    imports: [
-        BrowserModule,
-        TranslateModule.forRoot({
-            missingTranslationHandler: {provide: MissingTranslationHandler, useClass: MyMissingTranslationHandler},
-            useDefaultLang: false
-        })
-    ],
-    providers: [
-
-    ],
-    bootstrap: [AppComponent]
+  imports: [
+    BrowserModule,
+    TranslateModule.forRoot({
+      missingTranslationHandler: {
+        provide: MissingTranslationHandler,
+        useClass: MyMissingTranslationHandler,
+      },
+      useDefaultLang: false,
+    }),
+  ],
+  providers: [],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
 ### Parser
@@ -493,12 +579,14 @@ export class AppModule { }
 If you need it for some reason, you can use the `TranslateParser` service.
 
 #### Methods:
+
 - `interpolate(expr: string | Function, params?: any): string`: Interpolates a string to replace parameters or calls the interpolation function with the parameters.
 
-    `This is a {{ key }}` ==> `This is a value` with `params = { key: "value" }`
-    `(params) => \`This is a ${params.key}\` ==> `This is a value` with `params = { key: "value" }`
-- `getValue(target: any, key: string): any`:  Gets a value from an object by composed key
-     `parser.getValue({ key1: { keyA: 'valueI' }}, 'key1.keyA') ==> 'valueI'`
+  `This is a {{ key }}` ==> `This is a value` with `params = { key: "value" }`
+  `(params) => \`This is a ${params.key}\` ==> `This is a value` with `params = { key: "value" }`
+
+- `getValue(target: any, key: string): any`: Gets a value from an object by composed key
+  `parser.getValue({ key1: { keyA: 'valueI' }}, 'key1.keyA') ==> 'valueI'`
 
 ## FAQ
 
@@ -515,6 +603,7 @@ If you're using an old version of Angular and ngx-translate requires a newer ver
 If you want to reload the translations and see the update on all your components without reloading the page, you have to load the translations manually and call `setTranslation` function which triggers `onTranslationChange`.
 
 ## Plugins
+
 - [Localize Router](https://github.com/Greentube/localize-router) by @meeroslav: An implementation of routes localization for Angular. If you need localized urls (for example /fr/page and /en/page).
 - [.po files Loader](https://github.com/biesbjerg/ngx-translate-po-http-loader) by @biesbjerg: Use .po translation files with ngx-translate
 - [browser.i18n Loader](https://github.com/pearnaly/ngx-translate-browser-i18n-loader) by @pearnaly: loader for native translation files of browser extensions.
@@ -530,6 +619,7 @@ If you want to reload the translations and see the update on all your components
 - [ngx-translate-cut](https://github.com/bartholomej/ngx-translate-cut) by @bartholomej: Simple and useful pipe for cutting translations ✂️
 
 ## Editors
+
 - [BabelEdit](https://www.codeandweb.com/babeledit) — translation editor for JSON files
 - [Translation Manager](https://translation-manager-86c3d.firebaseapp.com/) — Progressive web-app, translation editor for JSON files
 - [Crowdl.io](https://crowdl.io) — Free translation management and crowd-translations tool with support for JSON files
@@ -539,11 +629,10 @@ If you want to reload the translations and see the update on all your components
 ### Extensions
 
 #### VScode
+
 - [Generate Translation](https://marketplace.visualstudio.com/items?itemName=thiagocordeirooo.generate-translation) by [@thiagocordeirooo](https://github.com/thiagocordeirooo): A visual studio code extension for you to generate the translations without leaving the current file.
 - [Lingua](https://marketplace.visualstudio.com/items?itemName=chr33z.lingua-vscode&utm_source=www.vsixhub.com) by [@chr33z](https://github.com/chr33z): A visual studio code extension to help managing translations for ngx-translate - featuring inline translation lookup and in-place translation creation and editing.
 
-
-
 ## Additional Framework Support
 
-* [Use with NativeScript](https://github.com/NathanWalker/nativescript-ng2-translate/issues/5#issuecomment-257606661)
+- [Use with NativeScript](https://github.com/NathanWalker/nativescript-ng2-translate/issues/5#issuecomment-257606661)

--- a/projects/ngx-translate/core/src/lib/translate-context.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate-context.directive.ts
@@ -1,0 +1,74 @@
+import { Directive, Inject, Injectable, Input, Optional, Self, SkipSelf, TemplateRef, ViewContainerRef } from '@angular/core';
+import { map, Observable, zip } from 'rxjs';
+import { MissingTranslationHandler } from './missing-translation-handler';
+import { TranslateCompiler } from './translate.compiler';
+import { TranslateLoader } from './translate.loader';
+import { TranslateParser } from './translate.parser';
+import { DEFAULT_LANGUAGE, TranslateService, USE_DEFAULT_LANG, USE_EXTEND, USE_STORE } from './translate.service';
+import { TranslateStore } from './translate.store';
+
+
+@Injectable()
+class TranslateContextService extends TranslateService {
+
+  constructor(
+    @Inject(TranslateService) @Optional() @SkipSelf() private parentContext: TranslateService,
+
+    store: TranslateStore,
+    currentLoader: TranslateLoader,
+    compiler: TranslateCompiler,
+    parser: TranslateParser,
+    missingTranslationHandler: MissingTranslationHandler,
+    @Inject(DEFAULT_LANGUAGE) defaultLanguage: string,
+    @Inject(USE_DEFAULT_LANG) useDefaultLang: boolean = true,
+    @Inject(USE_STORE) isolate: boolean = false,
+    @Inject(USE_EXTEND) extend: boolean = false
+  ) {
+    super(store, currentLoader, compiler, parser, missingTranslationHandler, useDefaultLang, isolate, extend, defaultLanguage);
+  }
+
+  params = {};
+  namespace: string | null = null;
+
+  public override get(key: string | Array<string>, interpolateParams?: {}): Observable<any> {
+
+    const paramsWithContext = { ...this.params, ...interpolateParams };
+
+    let result$ = this.parentContext.get(key, paramsWithContext);
+
+    if (this.namespace) {
+      const namespacedKey = `${this.namespace}.${key}`;
+
+      result$ = zip(result$, this.parentContext.get(namespacedKey, paramsWithContext)).pipe(
+        map(([label, namespacedLabel]) => namespacedLabel === namespacedKey ? label : namespacedLabel)
+      );
+    }
+
+    return result$;
+  }
+
+}
+
+@Directive({
+  selector: '[translateContext],[ngx-translateContext]',
+  providers: [{ provide: TranslateService, useClass: TranslateContextService }]
+})
+export class TranslateContextDirective {
+
+  constructor(
+    @Inject(TranslateService) @Self() private contextTranslateService: TranslateContextService,
+    private templateRef: TemplateRef<any>,
+    private viewContainer: ViewContainerRef
+  ) { }
+
+
+  @Input() set translateContext(params: {}) {
+    this.contextTranslateService.params = params;
+    this.viewContainer.clear();
+    this.viewContainer.createEmbeddedView(this.templateRef);
+  }
+
+  @Input() set translateContextNamespace(namespace: string) {
+    this.contextTranslateService.namespace = namespace;
+  }
+}

--- a/projects/ngx-translate/core/src/lib/translate-context.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate-context.service.ts
@@ -1,0 +1,49 @@
+import { Inject, Injectable, Optional, SkipSelf } from "@angular/core";
+import { map, Observable, zip } from "rxjs";
+import { MissingTranslationHandler } from "./missing-translation-handler";
+import { TranslateCompiler } from "./translate.compiler";
+import { TranslateLoader } from "./translate.loader";
+import { TranslateParser } from "./translate.parser";
+import { DEFAULT_LANGUAGE, TranslateService, USE_DEFAULT_LANG, USE_EXTEND, USE_STORE } from "./translate.service";
+import { TranslateStore } from "./translate.store";
+
+@Injectable()
+export class TranslateContextService extends TranslateService {
+
+  constructor(
+    @Inject(TranslateService) @Optional() @SkipSelf() private parentContext: TranslateService,
+
+    store: TranslateStore,
+    currentLoader: TranslateLoader,
+    compiler: TranslateCompiler,
+    parser: TranslateParser,
+    missingTranslationHandler: MissingTranslationHandler,
+    @Inject(DEFAULT_LANGUAGE) defaultLanguage: string,
+    @Inject(USE_DEFAULT_LANG) useDefaultLang: boolean = true,
+    @Inject(USE_STORE) isolate: boolean = false,
+    @Inject(USE_EXTEND) extend: boolean = false
+  ) {
+    super(store, currentLoader, compiler, parser, missingTranslationHandler, useDefaultLang, isolate, extend, defaultLanguage);
+  }
+
+  params = {};
+  namespace: string | null = null;
+
+  public override get(key: string | Array<string>, interpolateParams?: {}): Observable<any> {
+
+    const paramsWithContext = { ...this.params, ...interpolateParams };
+
+    let result$ = this.parentContext.get(key, paramsWithContext);
+
+    if (this.namespace) {
+      const namespacedKey = `${this.namespace}.${key}`;
+
+      result$ = zip(result$, this.parentContext.get(namespacedKey, paramsWithContext)).pipe(
+        map(([label, namespacedLabel]) => namespacedLabel === namespacedKey ? label : namespacedLabel)
+      );
+    }
+
+    return result$;
+  }
+
+}

--- a/projects/ngx-translate/core/src/lib/translate-namespace.directive.ts
+++ b/projects/ngx-translate/core/src/lib/translate-namespace.directive.ts
@@ -2,11 +2,12 @@ import { Directive, Inject, Input, Self, TemplateRef, ViewContainerRef } from '@
 import { TranslateContextService } from './translate-context.service';
 import { TranslateService } from './translate.service';
 
+
 @Directive({
-  selector: '[translateContext],[ngx-translateContext]',
+  selector: '[translateNamespace],[ngx-translateNamespace]',
   providers: [{ provide: TranslateService, useClass: TranslateContextService }]
 })
-export class TranslateContextDirective {
+export class TranslateNamespaceDirective {
 
   constructor(
     @Inject(TranslateService) @Self() private contextTranslateService: TranslateContextService,
@@ -15,13 +16,9 @@ export class TranslateContextDirective {
   ) { }
 
 
-  @Input() set translateContext(params: {}) {
-    this.contextTranslateService.params = params;
+  @Input() set translateNamespace(namespace: string) {
+    this.contextTranslateService.namespace = namespace;
     this.viewContainer.clear();
     this.viewContainer.createEmbeddedView(this.templateRef);
-  }
-
-  @Input() set translateContextNamespace(namespace: string) {
-    this.contextTranslateService.namespace = namespace;
   }
 }

--- a/projects/ngx-translate/core/src/public_api.ts
+++ b/projects/ngx-translate/core/src/public_api.ts
@@ -8,6 +8,7 @@ import { TranslatePipe } from "./lib/translate.pipe";
 import { TranslateStore } from "./lib/translate.store";
 import { USE_DEFAULT_LANG, DEFAULT_LANGUAGE, USE_STORE, TranslateService, USE_EXTEND } from "./lib/translate.service";
 import { TranslateContextDirective } from "./lib/translate-context.directive";
+import { TranslateNamespaceDirective } from "./lib/translate-namespace.directive";
 
 export * from "./lib/translate.loader";
 export * from "./lib/translate.service";
@@ -35,12 +36,14 @@ export interface TranslateModuleConfig {
   declarations: [
     TranslatePipe,
     TranslateDirective,
-    TranslateContextDirective
+    TranslateContextDirective,
+    TranslateNamespaceDirective
   ],
   exports: [
     TranslatePipe,
     TranslateDirective,
-    TranslateContextDirective
+    TranslateContextDirective,
+    TranslateNamespaceDirective
   ]
 })
 export class TranslateModule {

--- a/projects/ngx-translate/core/src/public_api.ts
+++ b/projects/ngx-translate/core/src/public_api.ts
@@ -1,12 +1,13 @@
-import {NgModule, ModuleWithProviders, Provider} from "@angular/core";
-import {TranslateLoader, TranslateFakeLoader} from "./lib/translate.loader";
-import {MissingTranslationHandler, FakeMissingTranslationHandler} from "./lib/missing-translation-handler";
-import {TranslateParser, TranslateDefaultParser} from "./lib/translate.parser";
-import {TranslateCompiler, TranslateFakeCompiler} from "./lib/translate.compiler";
-import {TranslateDirective} from "./lib/translate.directive";
-import {TranslatePipe} from "./lib/translate.pipe";
-import {TranslateStore} from "./lib/translate.store";
-import {USE_DEFAULT_LANG, DEFAULT_LANGUAGE, USE_STORE, TranslateService, USE_EXTEND} from "./lib/translate.service";
+import { NgModule, ModuleWithProviders, Provider } from "@angular/core";
+import { TranslateLoader, TranslateFakeLoader } from "./lib/translate.loader";
+import { MissingTranslationHandler, FakeMissingTranslationHandler } from "./lib/missing-translation-handler";
+import { TranslateParser, TranslateDefaultParser } from "./lib/translate.parser";
+import { TranslateCompiler, TranslateFakeCompiler } from "./lib/translate.compiler";
+import { TranslateDirective } from "./lib/translate.directive";
+import { TranslatePipe } from "./lib/translate.pipe";
+import { TranslateStore } from "./lib/translate.store";
+import { USE_DEFAULT_LANG, DEFAULT_LANGUAGE, USE_STORE, TranslateService, USE_EXTEND } from "./lib/translate.service";
+import { TranslateContextDirective } from "./lib/translate-context.directive";
 
 export * from "./lib/translate.loader";
 export * from "./lib/translate.service";
@@ -33,11 +34,13 @@ export interface TranslateModuleConfig {
 @NgModule({
   declarations: [
     TranslatePipe,
-    TranslateDirective
+    TranslateDirective,
+    TranslateContextDirective
   ],
   exports: [
     TranslatePipe,
-    TranslateDirective
+    TranslateDirective,
+    TranslateContextDirective
   ]
 })
 export class TranslateModule {
@@ -48,15 +51,15 @@ export class TranslateModule {
     return {
       ngModule: TranslateModule,
       providers: [
-        config.loader || {provide: TranslateLoader, useClass: TranslateFakeLoader},
-        config.compiler || {provide: TranslateCompiler, useClass: TranslateFakeCompiler},
-        config.parser || {provide: TranslateParser, useClass: TranslateDefaultParser},
-        config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
+        config.loader || { provide: TranslateLoader, useClass: TranslateFakeLoader },
+        config.compiler || { provide: TranslateCompiler, useClass: TranslateFakeCompiler },
+        config.parser || { provide: TranslateParser, useClass: TranslateDefaultParser },
+        config.missingTranslationHandler || { provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler },
         TranslateStore,
-        {provide: USE_STORE, useValue: config.isolate},
-        {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
-        {provide: USE_EXTEND, useValue: config.extend},
-        {provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage},
+        { provide: USE_STORE, useValue: config.isolate },
+        { provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang },
+        { provide: USE_EXTEND, useValue: config.extend },
+        { provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage },
         TranslateService
       ]
     };
@@ -69,14 +72,14 @@ export class TranslateModule {
     return {
       ngModule: TranslateModule,
       providers: [
-        config.loader || {provide: TranslateLoader, useClass: TranslateFakeLoader},
-        config.compiler || {provide: TranslateCompiler, useClass: TranslateFakeCompiler},
-        config.parser || {provide: TranslateParser, useClass: TranslateDefaultParser},
-        config.missingTranslationHandler || {provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler},
-        {provide: USE_STORE, useValue: config.isolate},
-        {provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang},
-        {provide: USE_EXTEND, useValue: config.extend},
-        {provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage},
+        config.loader || { provide: TranslateLoader, useClass: TranslateFakeLoader },
+        config.compiler || { provide: TranslateCompiler, useClass: TranslateFakeCompiler },
+        config.parser || { provide: TranslateParser, useClass: TranslateDefaultParser },
+        config.missingTranslationHandler || { provide: MissingTranslationHandler, useClass: FakeMissingTranslationHandler },
+        { provide: USE_STORE, useValue: config.isolate },
+        { provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang },
+        { provide: USE_EXTEND, useValue: config.extend },
+        { provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage },
         TranslateService
       ]
     };

--- a/projects/ngx-translate/core/tests/translate-context.directive.spec.ts
+++ b/projects/ngx-translate/core/tests/translate-context.directive.spec.ts
@@ -1,0 +1,127 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateContextDirective } from '../src/lib/translate-context.directive';
+import { TranslateModule, TranslateService } from '../src/public_api';
+
+
+const labels = {
+  LABEL: 'context: {{param1}} {{param2}} {{param3}}',
+
+  gc: {
+    key1: 'gc.k1',
+    key2: 'gc.k2',
+    key3: 'gc.k3'
+  },
+
+  overrides: {
+    gc: {
+      key1: 'root.k1',
+      key2: 'root.k2'
+    }
+  }
+
+};
+
+@Component({
+  selector: 'root-component',
+  template: `
+    <div *translateContext="rootContext; namespace 'overrides'">
+      <div class="root-with-context" translate="LABEL"></div>
+      <child-component></child-component>
+    </div>
+
+  `
+})
+class RootComponent{
+  rootContext = { param1: 'r1', param2: 'r2', param3: 'r3' };
+}
+
+@Component({
+  selector: 'child-component',
+  template: `
+    <div class="child-no-context" translate="LABEL"></div>
+
+    <div *translateContext="childContext">
+      <div class="child-with-context" translate="LABEL"></div>
+      <grandchild-component></grandchild-component>
+    </div>
+  `
+})
+class ChildComponent{  
+  childContext = { param2: 'c2' }
+}
+
+@Component({
+  selector: 'grandchild-component',
+  template: `
+    <div class="grandchild-no-context" translate="LABEL"></div>
+
+    <div *translateContext="grandchildContext">
+      <div class="grandchild-with-context" translate="LABEL"></div>
+    </div>
+
+
+    <div class="grandchild-key1" translate="gc.key1"></div>
+
+    <div *translateContext="{}; namespace 'gc'">
+      <div class="grandchild-key2" translate="key2"></div>
+      <div class="grandchild-key3" translate="key3"></div>
+    </div>
+  `
+})
+class GrandChildComponent{
+  grandchildContext = { param3: 'gc3' }
+}
+
+
+describe('TranslateContextDirective', () => {
+  let fixture: ComponentFixture<RootComponent>;
+  let nativeElement: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RootComponent, ChildComponent, GrandChildComponent, TranslateContextDirective ],
+      imports: [TranslateModule.forRoot()]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    const translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('en', labels);
+    translateService.currentLang = 'en';
+
+    fixture = TestBed.createComponent(RootComponent);
+    fixture.detectChanges();
+    nativeElement = fixture.nativeElement;
+  });
+
+
+
+  it('should provide context params for immediate view children', () => {
+    expect(nativeElement.getElementsByClassName('root-with-context')[0].innerHTML).toBe('context: r1 r2 r3');
+  });
+
+  it('should inherit context params from parent component', () => {
+    expect(nativeElement.getElementsByClassName('child-no-context')[0].innerHTML).toBe('context: r1 r2 r3');
+  });
+
+  it('should merge context params over inherited context', () => {
+    expect(nativeElement.getElementsByClassName('child-with-context')[0].innerHTML).toBe('context: r1 c2 r3');
+  });
+
+  it('should inherit context params from parent and grand parent components', () => {
+    expect(nativeElement.getElementsByClassName('grandchild-no-context')[0].innerHTML).toBe('context: r1 c2 r3');
+  });
+
+  it('should merge context params over parent and grand parent context', () => {
+    expect(nativeElement.getElementsByClassName('grandchild-with-context')[0].innerHTML).toBe('context: r1 c2 gc3');
+  });
+
+  it('should prefix the key with the context namespace', () => {
+    expect(nativeElement.getElementsByClassName('grandchild-key1')[0].innerHTML).toBe('root.k1');
+    expect(nativeElement.getElementsByClassName('grandchild-key2')[0].innerHTML).toBe('root.k2');
+    expect(nativeElement.getElementsByClassName('grandchild-key3')[0].innerHTML).toBe('gc.k3');
+  });
+
+});

--- a/projects/ngx-translate/core/tests/translate-namespace.directive.spec.ts
+++ b/projects/ngx-translate/core/tests/translate-namespace.directive.spec.ts
@@ -1,12 +1,10 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateContextDirective } from '../src/lib/translate-context.directive';
+import { TranslateNamespaceDirective } from '../src/lib/translate-namespace.directive';
 import { TranslateModule, TranslateService } from '../src/public_api';
 
 
 const labels = {
-  LABEL: 'context: {{param1}} {{param2}} {{param3}}',
-
   gc: {
     key1: 'gc.k1',
     key2: 'gc.k2',
@@ -25,8 +23,7 @@ const labels = {
 @Component({
   selector: 'root-component',
   template: `
-    <div *translateContext="rootContext; namespace 'overrides'">
-      <div class="root-with-context" translate="LABEL"></div>
+    <div *translateNamespace="'overrides'">
       <child-component></child-component>
     </div>
 
@@ -39,12 +36,7 @@ class RootComponent {
 @Component({
   selector: 'child-component',
   template: `
-    <div class="child-no-context" translate="LABEL"></div>
-
-    <div *translateContext="childContext">
-      <div class="child-with-context" translate="LABEL"></div>
-      <grandchild-component></grandchild-component>
-    </div>
+    <grandchild-component></grandchild-component>
   `
 })
 class ChildComponent {
@@ -54,16 +46,9 @@ class ChildComponent {
 @Component({
   selector: 'grandchild-component',
   template: `
-    <div class="grandchild-no-context" translate="LABEL"></div>
-
-    <div *translateContext="grandchildContext">
-      <div class="grandchild-with-context" translate="LABEL"></div>
-    </div>
-
-
     <div class="grandchild-key1" translate="gc.key1"></div>
 
-    <div *translateContext="{}; namespace 'gc'">
+    <div *translateNamespace="'gc'">
       <div class="grandchild-key2" translate="key2"></div>
       <div class="grandchild-key3" translate="key3"></div>
     </div>
@@ -74,13 +59,13 @@ class GrandChildComponent {
 }
 
 
-describe('TranslateContextDirective', () => {
+describe('TranslateNamespaceDirective', () => {
   let fixture: ComponentFixture<RootComponent>;
   let nativeElement: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [RootComponent, ChildComponent, GrandChildComponent, TranslateContextDirective],
+      declarations: [RootComponent, ChildComponent, GrandChildComponent, TranslateNamespaceDirective],
       imports: [TranslateModule.forRoot()]
     })
       .compileComponents();
@@ -96,27 +81,6 @@ describe('TranslateContextDirective', () => {
     nativeElement = fixture.nativeElement;
   });
 
-
-
-  it('should provide context params for immediate view children', () => {
-    expect(nativeElement.getElementsByClassName('root-with-context')[0].innerHTML).toBe('context: r1 r2 r3');
-  });
-
-  it('should inherit context params from parent component', () => {
-    expect(nativeElement.getElementsByClassName('child-no-context')[0].innerHTML).toBe('context: r1 r2 r3');
-  });
-
-  it('should merge context params over inherited context', () => {
-    expect(nativeElement.getElementsByClassName('child-with-context')[0].innerHTML).toBe('context: r1 c2 r3');
-  });
-
-  it('should inherit context params from parent and grand parent components', () => {
-    expect(nativeElement.getElementsByClassName('grandchild-no-context')[0].innerHTML).toBe('context: r1 c2 r3');
-  });
-
-  it('should merge context params over parent and grand parent context', () => {
-    expect(nativeElement.getElementsByClassName('grandchild-with-context')[0].innerHTML).toBe('context: r1 c2 gc3');
-  });
 
   it('should prefix the key with the context namespace', () => {
     expect(nativeElement.getElementsByClassName('grandchild-key1')[0].innerHTML).toBe('root.k1');


### PR DESCRIPTION
This PR does not contain breaking changes.

Extract from README.md
---
#### 7. Use translate namespace:

You can namespace your keys using the `*translateNamespace` structural directive

```html
<ul *translateNamespace="'somApp.pageX.contentComponent'">
  <li translate>key1</li>
  <li translate>key2</li>
  <li translate>key3</li>
</ul>
```

Would translate the `somApp.pageX.contentComponent.key1`, `somApp.pageX.contentComponent.key2` and `somApp.pageX.contentComponent.key3` keys.

The namespaces directive are also stackable:

```html
// app.component.html
<div *translateNamespace="'someApp'">
  <router-outlet></router-outlet>
</div>
```

```html
// pageX.component.html
<div *translateNamespace="'pageX'">
  <content-component></content-component>
</div>
```

```html
// content.component.html
<ul *translateNamespace="'contentComponent'">
  <li translate>key1</li>
  <li translate>key2</li>
  <li translate>key3</li>
</ul>
```

> **Note:**
>
> To avoid breaking changes, the translation resolution will fallback to a non namespaced key if the key isn't found in a given namespace.

#### 8. Use translate context:

You can use the `*translateContext` structural directive to provide the context of all child translation to avoir to repeat the translateParams directive.

```json
{
  "person": {
    "bio": {
      "nameColumn": "{{firstName}} {{lastName}}",
      "addressColumn": "{{address}} {{city}} {{state}}",
      "age": "{{age}} years old"
    }
  }
}
```

```html
<ul *translateContext="person">
  <li translate>person.bio.nameColumn</li>
  <li translate>person.bio.addressColumn</li>
  <li translate>person.bio.age</li>
</ul>
```

The context are also stackable. Meaning that context from parent dom element will be inherited and merged with the current context.

Since `*translateNamespace` and `*translateContext` are structural directives and Angular limits one structural directive per element, it is possible to provide the namespace on the `*translateContext` directive:

```html
<ul *translateContext="person; namespace: 'person.bio' ">
  <li translate>nameColumn</li>
  <li translate>addressColumn</li>
  <li translate>age</li>
</ul>
```
