### PR TITLE
Translate objects recursively when key points to object in translations

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.parser.ts
+++ b/projects/ngx-translate/core/src/lib/translate.parser.ts
@@ -8,7 +8,7 @@ export abstract class TranslateParser {
    * @param expr
    * @param params
    */
-  abstract interpolate(expr: string | Function, params?: any): string | undefined;
+  abstract interpolate(expr: string | Function | object, params?: any): string | object | undefined;
 
   /**
    * Gets a value from an object by composed key
@@ -23,13 +23,20 @@ export abstract class TranslateParser {
 export class TranslateDefaultParser extends TranslateParser {
   templateMatcher: RegExp = /{{\s?([^{}\s]*)\s?}}/g;
 
-  public interpolate(expr: string | Function, params?: any): string {
+  public interpolate(expr: string | Function | object, params?: any): string | object {
     let result: string;
 
     if (typeof expr === 'string') {
       result = this.interpolateString(expr, params);
     } else if (typeof expr === 'function') {
       result = this.interpolateFunction(expr, params);
+    } else if (typeof expr === 'object') {
+      return Object.fromEntries(
+        Object.entries(expr).map(([key, value]) => [
+          key,
+          this.interpolate(value, params)
+        ])
+      );
     } else {
       // this should not happen, but an unrelated TranslateService test depends on it
       result = expr as string;

--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -318,7 +318,7 @@ export class TranslateService {
    * Returns the parsed result of the translations
    */
   public getParsedResult(translations: any, key: any, interpolateParams?: Object): any {
-    let res: string | Observable<string> | undefined;
+    let res: string | Observable<string> | object | undefined;
 
     if (key instanceof Array) {
       let result: any = {},

--- a/projects/ngx-translate/core/tests/translate.parser.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.parser.spec.ts
@@ -27,6 +27,10 @@ describe('Parser', () => {
     expect(parser.interpolate("This is a {{ key1.key2.key3 }}", {key1: {key2: {key3: "value3"}}})).toEqual("This is a value3");
   });
 
+  it('should interpolate objects', () => {
+    expect(parser.interpolate({ TEST: 'This is a {{ key }}' }, { key: 'value' })).toEqual({ TEST: 'This is a value' });
+  });
+
   it('should support interpolation functions', () => {
     expect(parser.interpolate((v: string) => v.toUpperCase() + ' YOU!', 'bless')).toBe('BLESS YOU!');
   });

--- a/projects/ngx-translate/core/tests/translate.pipe.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.pipe.spec.ts
@@ -133,6 +133,28 @@ describe('TranslatePipe', () => {
       .toEqual("This is a test with param-1 and param-2");
   });
 
+  it('should translate an object', () => {
+    translate.setTranslation('en', {
+      OBJECT: {
+        TEST: 'This is a test'
+      }
+    });
+    translate.use('en');
+
+    expect(translatePipe.transform('OBJECT')).toEqual({ TEST: 'This is a test' });
+  });
+
+  it('should translate an object with another object as string parameters', () => {
+    translate.setTranslation('en', {
+      OBJECT: {
+        TEST: 'This is a test {{param}}'
+      }
+    });
+    translate.use('en');
+
+    expect(translatePipe.transform('OBJECT', { param: 'with param-1' })).toEqual({ TEST: 'This is a test with param-1' });
+  });
+
   it('should update the value when the parameters change', () => {
     translate.setTranslation('en', {"TEST": "This is a test {{param}}"});
     translate.use('en');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2017",
+    "target": "es2019",
     "module": "es2020",
     "lib": [
       "es2020",


### PR DESCRIPTION
fix for #946

Motivation:
I want to be able to use the translate pipe in combination with the `*ngFor` keyword in my angular components

With this Pull Request the following now works...

translations.json
```json
{
  OBJECT: {
    TEST: 'this is a test {{key}}',
    ANOTHER_TEST: 'this is another test {{key}}'
  }
}
```

any view
```html
<ul>
  <li *ngFor="let translation of 'OBJECT' | translate: { key: 'value' } | keyvalue">{ translation.value }</li>
</ul>
```

result
```html
<ul>
  <li>this is a test value</li>
  <li>this is another test value</li>
</ul>
```

previously the interpolation would fail, resulting in
```html
<ul>
  <li>this is a test {{key}}</li>
  <li>this is another test {{key}}</li>
</ul>
```