### PR TITLE
fix(service): allow setting translations in deep objects

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -458,7 +458,15 @@ export class TranslateService {
    * Sets the translated value of a key, after compiling it
    */
   public set(key: string, value: string, lang: string = this.currentLang): void {
-    this.translations[lang][key] = this.compiler.compile(value, lang);
+    const keys = key.split('.');
+    const translationKey = keys.pop() as string;
+    const translation = keys.reduce((translation, subKey) => {
+      if (!translation[subKey] || typeof translation[subKey] !== 'object') {
+        translation[subKey] = {};
+      }
+      return translation[subKey];
+    } , this.translations[lang]);
+    translation[translationKey] = this.compiler.compile(value, lang);
     this.updateLangs();
     this.onTranslationChange.emit({lang: lang, translations: this.translations[lang]});
   }

--- a/projects/ngx-translate/core/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.service.spec.ts
@@ -397,6 +397,21 @@ describe('TranslateService', () => {
     translate.set("TEST", "This is a test", 'en');
   });
 
+  it('should set a nested property in the translation value', () => {
+    const translation = { name: 'Name' } as any;
+    const defaultLang = 'en';
+    translate.setTranslation(defaultLang, translation);
+    translate.set('profile.name', 'Profile Name', defaultLang);
+    expect(translation?.profile?.name).toEqual('Profile Name');
+  });
+
+  it('should replace an existing translation ', () => {
+    const translation = { name: 'OldName' } as any;
+    translate.setTranslation('en', translation);
+    translate.set('name', 'New Name', 'en');
+    expect(translation.name).toEqual('New Name');
+  });
+
   it('should trigger an event when the lang changes', () => {
     let tr = {"TEST": "This is a test"};
     translate.setTranslation('en', tr);


### PR DESCRIPTION
This PR fixes the issue mentioned in #216 .

When we pass a key with nested properties, for example, `profilePage.header.name`, it will set the key as is instead of creating the necessary nested objects.

<table>
<tr>
<td> Currently </td> <td> After this PR </td>
</tr>
<tr>
<td>

```json
{
 "profilePage.header.name": "Test"
}
```

</td>
<td>

```json
{
 "profilePage": {
     "header": {
         "name": "Test"   
     }
  }
}
```

</td>
</tr>
</table>

This change will check if the received key has `.`, creating the nested objects automatically if they do not exist in the appropriate translation object.
