### PR TITLE
fix(pipe): isObservable usage

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -28,7 +28,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     };
     if (translations) {
       let res = this.translate.getParsedResult(translations, key, interpolateParams);
-      if (isObservable(res.subscribe)) {
+      if (isObservable(res)) {
         res.subscribe(onTranslation);
       } else {
         onTranslation(res);

--- a/projects/ngx-translate/core/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/core/src/lib/translate.pipe.ts
@@ -1,6 +1,6 @@
-import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform} from '@angular/core';
-import {isObservable} from 'rxjs';
-import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
+import {ChangeDetectorRef, Injectable, OnDestroy, Pipe, PipeTransform} from '@angular/core';
+import {isObservable, Observable} from 'rxjs';
+import {LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
 import {equals, isDefined} from './util';
 import { Subscription } from 'rxjs';
 
@@ -27,7 +27,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
       this._ref.markForCheck();
     };
     if (translations) {
-      let res = this.translate.getParsedResult(translations, key, interpolateParams);
+      let res: Observable<string> | string = this.translate.getParsedResult(translations, key, interpolateParams);
       if (isObservable(res)) {
         res.subscribe(onTranslation);
       } else {


### PR DESCRIPTION
### isObservable(res) instead of isObservable(res.subscribe)
I changed the usage of isObservable function to the correct one. Previously, it checks the subscribe function itself while it should check the observable itself. I also add a test that describes in which case it could lead to problem. 

### Without my fix the test is red and the actual result is 
`"{"operator": [Function anonymous], "source": {"_subscribe": [Function anonymous]}}" `

<img width="800" alt="image" src="https://user-images.githubusercontent.com/78817315/217788792-a04cb35e-279e-438f-bd5b-d57bc5f0983b.png">

### With my fix the test is green.
<img width="800" alt="image" src="https://user-images.githubusercontent.com/78817315/217789097-d0d4c769-7e0e-4ad9-a7fd-bb4faa8bda3d.png">

In my test I described the scenario of a race condition when there is a bit delay of loading new language translation (after switching) and the usage MissingHandler with observable takes place.

### P.S.
In many cases the next tick will solve the problem and user will see the correct translation, but there is a chance to see the stringified observable `"{"operator": [Function anonymous], "source": {"_subscribe": [Function anonymous]}}" `

In my PR I also removed some redundat imports.

