### PR TITLE
Fix node.lastKey never being set

### DIFF
--- a/packages/core/lib/translate.directive.ts
+++ b/packages/core/lib/translate.directive.ts
@@ -111,7 +111,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
       this.lastParams = this.currentParams;
 
       let onTranslation = (res: unknown) => {
-        if (res !== key) {
+        if (res !== key || || !node.lastKey) {
           node.lastKey = key;
         }
         if (!node.originalContent) {

--- a/packages/core/lib/translate.directive.ts
+++ b/packages/core/lib/translate.directive.ts
@@ -111,7 +111,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
       this.lastParams = this.currentParams;
 
       let onTranslation = (res: unknown) => {
-        if (res !== key || || !node.lastKey) {
+        if (res !== key || !node.lastKey) {
           node.lastKey = key;
         }
         if (!node.originalContent) {


### PR DESCRIPTION
In cases where the key and translated value are the same or translated value isn't available the node.lastKey is never set.

This causes issue #1416 where the value for the node constantly set to the same string.