### PR TITLE
feat(core): Make TranslatePipe and TranslateDirective standalone

### DIFF
--- a/packages/core/lib/translate.directive.ts
+++ b/packages/core/lib/translate.directive.ts
@@ -4,6 +4,7 @@ import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationCh
 import {equals, isDefined} from './util';
 
 @Directive({
+  standalone: true,
   selector: '[translate],[ngx-translate]'
 })
 export class TranslateDirective implements AfterViewChecked, OnDestroy {

--- a/packages/core/lib/translate.pipe.ts
+++ b/packages/core/lib/translate.pipe.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 
 @Injectable()
 @Pipe({
+  standalone: true,
   name: 'translate',
   pure: false // required to update the value when the promise is resolved
 })

--- a/packages/core/public-api.ts
+++ b/packages/core/public-api.ts
@@ -31,7 +31,7 @@ export interface TranslateModuleConfig {
 }
 
 @NgModule({
-  declarations: [
+  imports: [
     TranslatePipe,
     TranslateDirective
   ],


### PR DESCRIPTION
Make the TranslatePipe and TranslateDirective standalone so only those can be imported in a standalone component instead of the whole module.