### PR TITLE
'EventEmitter' and 'DefaultLangChangeEvent' is declared but its value is never read.

### DIFF
--- a/packages/core/lib/translate.pipe.ts
+++ b/packages/core/lib/translate.pipe.ts
@@ -1,6 +1,6 @@
-import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform} from '@angular/core';
+import {ChangeDetectorRef, Injectable, OnDestroy, Pipe, PipeTransform} from '@angular/core';
 import {isObservable} from 'rxjs';
-import {DefaultLangChangeEvent, LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
+import {LangChangeEvent, TranslateService, TranslationChangeEvent} from './translate.service';
 import {equals, isDefined} from './util';
 import { Subscription } from 'rxjs';
 


### PR DESCRIPTION
Fix unused imports I have just removed the one that were not used

issue : https://github.com/ngx-translate/core/issues/1463