### PR TITLE
Fixes #1479: always translate to the last requested language

### DIFF
--- a/packages/http-loader/tests/http-loader.spec.ts
+++ b/packages/http-loader/tests/http-loader.spec.ts
@@ -98,4 +98,28 @@ describe('TranslateLoader', () => {
     // mock response after the xhr request, otherwise it will be undefined
     http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test"});
   });
+
+  it('should get last requested lang', (done: Function) => {
+    // request en, fr then en
+    translate.use('en');
+    translate.use('fr');
+    translate.use('en');
+    jest.spyOn(http, 'expectOne');
+
+    // this will request the translation from the backend because we use a static files loader for TranslateService
+    translate.get('TEST').subscribe((res: string) => {
+      expect(res).toEqual('This is a test');
+      done()
+    });
+
+
+    // mock response after the xhr request, otherwise it will be undefined
+    http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test"});
+    // mock late fr response
+    setTimeout(()=> {
+      http.expectOne('/assets/i18n/fr.json').flush({"TEST": "This is a fr test"});
+    }, 10)
+
+  });
 });
+


### PR DESCRIPTION
### The current behavior:
The language change event would fire whenever a new translation was loaded.
When requesting a translation, if another translation is loading, the system would wait for it to finish and return that instead of the translation of the most recent set language.

### This Pull Request addresses this by:
Fixing the issue mentioned in #1479.
Adding a test to ensure the fix works as expected.
