### PR TITLE
Fix: Check for null values in isDict method

### DIFF
--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -56,7 +56,7 @@ export function isDefined(value: any): boolean {
 
 
 export function isDict(value: any): boolean {
-  return isObject(value) && !isArray(value);
+  return isObject(value) && !isArray(value) && value !== null;
 }
 
 


### PR DESCRIPTION
This pull request addresses a bug in the `isDict` method that previously did not explicitly check for null values. The original implementation of the `isDict` method only checked if the value was an object and not an array. 

This behavior is causing some translation values with null values to be converted into an empty object. 

**Changes made:**
1. Added a null check to the `isDict` method to ensure that null values are not incorrectly identified as dictionaries.