### PR TITLE
Fix getValue()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The internationalization (i18n) library for Angular.
 <br/>
 
-## Angular 16, 17, 18+
+## Angular 16, 17, 18, 19+
 
 The new [documentation](https://ngx-translate.org/) now covers installation on
 Angular 16+ and is divided into smaller, more readable sections, making it

--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -107,30 +107,31 @@ export function mergeDeep(target: any, source: any): any {
  * @param target
  * @param key
  */
-export function getValue(target: any, key: string): any
-{
-  const keys = key.split(".");
-
-  key = "";
-  do
-  {
-    key += keys.shift();
-    if (isDefined(target) && isDefined(target[key]) && (isDict(target[key]) ||isArray(target[key]) || !keys.length))
-    {
-      target = target[key];
-      key = "";
-    }
-    else if (!keys.length)
-    {
-      target = undefined;
-    }
-    else
-    {
-      key += ".";
-    }
-  } while (keys.length);
-
+export function getValue(target: any, key: string) {
+  let keys = key.split(".");
+  let matchedKey: string|undefined = key;
+  while(keys.length) {
+    [matchedKey, keys] = getLongestMatchingSubKey(target,keys);
+    if (matchedKey===undefined)
+      return undefined;
+    target = target[matchedKey];
+  }
   return target;
+}
+
+function getLongestMatchingSubKey(target: any, keys: string[]): [string|undefined, string[]] {
+  let key = '';
+  let matchedKey;
+  let size;
+  for (let i=0; i<keys.length; i++) {
+    key += keys[i];
+    if (isDefined(target[key])) {
+      matchedKey = key;
+      size = i+1;
+    }
+    key += '.';
+  }
+  return [matchedKey, isDefined(size) ? keys.slice(size) : keys];
 }
 
 /**

--- a/projects/ngx-translate/src/lib/utils.spec.ts
+++ b/projects/ngx-translate/src/lib/utils.spec.ts
@@ -226,6 +226,14 @@ describe("Utils", () =>
         'key1': "value1",
         'key1.key2': "value2"
       }, 'key1.key2')).toEqual("value2");
+      expect(getValue({
+        'key1': {'key3': "value1"},
+        'key1.key2': "value2"
+      }, 'key1.key2')).toEqual("value2");
+      expect(getValue({
+        'key1': ["a","b","c"],
+        'key1.key2': "value2"
+      }, 'key1.key2')).toEqual("value2");
 
       expect(getValue({'key1.key2': {key3: "value3"}}, 'key1.key2')).toEqual({key3: "value3"});
     });


### PR DESCRIPTION
It could not handle this case:
{
  "key1": {"key3": "value1"},
  "key1.key2": "value2"
}

I was not able to run the tests :-\ 
