### PR TITLE
feat: make interpolation functions protected to allow ineritance

### DIFF
--- a/projects/ngx-translate/src/lib/translate.parser.ts
+++ b/projects/ngx-translate/src/lib/translate.parser.ts
@@ -36,12 +36,12 @@ export class TranslateDefaultParser extends TranslateParser
     return undefined;
   }
 
-  private interpolateFunction(fn: InterpolateFunction, params?: InterpolationParameters): string
+  protected interpolateFunction(fn: InterpolateFunction, params?: InterpolationParameters): string
   {
     return fn(params);
   }
 
-  private interpolateString(expr: string, params?: InterpolationParameters): string
+  protected interpolateString(expr: string, params?: InterpolationParameters): string
   {
     if (!params)
     {


### PR DESCRIPTION
I have changed `private` to `protected` to have an ability to extend this class and override just one method. In my case I need to override logic in `interpolateString` method to use `''` instead of `substring` if value is not defined.