### PR TITLE
Improve type safety of TranslateService and TranslatePipe

### DIFF
--- a/projects/ngx-translate/src/lib/translate.parser.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.parser.spec.ts
@@ -29,7 +29,7 @@ describe('Parser', () => {
     });
 
     it('should support interpolation functions', () => {
-      const uc:InterpolateFunction = (params) => (params?.['x'] ?? '').toUpperCase() + ' YOU!';
+      const uc:InterpolateFunction = (params) => ((params?.['x'] ?? '') as string).toUpperCase() + ' YOU!';
 
       expect(parser.interpolate( uc , {"x":'bless'})).toBe('BLESS YOU!');
     });

--- a/projects/ngx-translate/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe.ts
@@ -27,7 +27,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
   constructor(private translate: TranslateService, private _ref: ChangeDetectorRef) {
   }
 
-  updateValue(key: string, interpolateParams?: object, translations?: InterpolatableTranslationObject): void {
+  updateValue(key: string, interpolateParams?: InterpolationParameters, translations?: InterpolatableTranslationObject): void {
     const onTranslation = (res: Translation) => {
       this.value = res !== undefined ? res : key;
       this.lastKey = key;
@@ -45,7 +45,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
   }
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  transform(query: string, ...args: any[]): any {
+  transform(query: string | undefined | null, ...args: any[]): Translation {
     if (!query || !query.length) {
       return query;
     }
@@ -55,7 +55,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
       return this.value;
     }
 
-    let interpolateParams: object | undefined = undefined;
+    let interpolateParams: InterpolationParameters | undefined = undefined;
     if (isDefinedAndNotNull(args[0]) && args.length) {
       if (isString(args[0]) && args[0].length) {
         // we accept objects written in the template such as {n:1}, {'n':1}, {n:'v'}

--- a/projects/ngx-translate/src/lib/translate.service.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.service.spec.ts
@@ -994,6 +994,7 @@ describe("TranslateService", () =>
     it("should handle language codes with underscores", () =>
     {
       spyOnProperty(window.navigator, "language", "get").and.returnValue("en_US");
+      spyOnProperty(window.navigator, "languages", "get").and.returnValue(["en_US"]);
 
       expect(translate.getBrowserLang()).toBe("en");
     });

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -13,8 +13,7 @@ export const USE_DEFAULT_LANG = new InjectionToken<string>('USE_DEFAULT_LANG');
 export const DEFAULT_LANGUAGE = new InjectionToken<string>('DEFAULT_LANGUAGE');
 export const USE_EXTEND = new InjectionToken<string>('USE_EXTEND');
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type InterpolationParameters = Record<string, any>;
+export type InterpolationParameters = Record<string, unknown>;
 
 export type Translation =
   string |


### PR DESCRIPTION
**Changes**

* `TranslatePipe` now explicitly accepts `null` and `undefined` and returns `Translation`. The code already guards against falsy values and specifying it explicitly helps when used with `strictNullChecks` in `tsconfig`. Otherwise, you may get a bunch of errors when an optional or nullable field is passed to the pipe.
* Replaced `any` with `unknown` in `InterpolationParams`.
* Fixes a test on non-English machines.