### PR TITLE
Add fast exit if no params provided

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -330,10 +330,14 @@ export class TranslateService {
   private getParsedResultForKey(key: string, interpolateParams?: InterpolationParameters): Translation|Observable<Translation>
   {
       const textToInterpolate = this.getTextToInterpolate(key);
-
+    
       if (isDefinedAndNotNull(textToInterpolate))
       {
+        //Fast exit to avoid overhead if no params provided
+        if(isDefinedAndNotNull(interpolateParams))
           return this.runInterpolation(textToInterpolate, interpolateParams);
+        else
+          return textToInterpolate;
       }
 
       const res = this.missingTranslationHandler.handle({


### PR DESCRIPTION
After analyse and debugg code we encounter that even we provide no params the logic runs through the interpolation stack.

If their no Params provide an exit is here already possible to return the translated value directly