### PR TITLE
refactor(utils): type inference

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.service.spec.ts
@@ -1,14 +1,18 @@
-import {fakeAsync, TestBed, tick} from "@angular/core/testing";
-import {Observable, of, timer, zip, defer, EMPTY} from "rxjs";
-import {take, toArray, first, map} from "rxjs/operators";
+import { Component } from "@angular/core";
+import { fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { RouterOutlet } from "@angular/router";
+import { defer, EMPTY, Observable, of, timer, zip } from "rxjs";
+import { first, map, take, toArray } from "rxjs/operators";
 import {
   LangChangeEvent,
+  provideTranslateService,
   TranslateLoader,
+  TranslateModule,
+  TranslatePipe,
   TranslateService,
-  TranslationChangeEvent, TranslationObject, Translation, provideTranslateService, TranslatePipe, TranslateModule
+  Translation,
+  TranslationChangeEvent, TranslationObject
 } from "../public-api";
-import {Component} from "@angular/core";
-import {RouterOutlet} from "@angular/router";
 
 
 let translations: TranslationObject = {"TEST": "This is a test"};
@@ -711,7 +715,7 @@ describe("TranslateService", () =>
       translate.onTranslationChange.subscribe((event: TranslationChangeEvent) =>
       {
         expect(event.translations).toBeDefined();
-        expect((event.translations)["TEST"]).toEqual("This is a test");
+        expect((event.translations)["TEST"] as string).toEqual("This is a test");
         expect(event.lang).toBe("en");
       });
       translate.set("TEST", "This is a test", "en");
@@ -725,7 +729,7 @@ describe("TranslateService", () =>
       translate.onTranslationChange.subscribe((event: TranslationChangeEvent) =>
       {
         expect(event.translations).toBeDefined();
-        expect((event.translations)["TEST"]).toEqual("This is a test");
+        expect((event.translations)["TEST"] as string).toEqual("This is a test");
         expect(event.lang).toBe("en");
       });
       translate.set("TEST", "This is a test");
@@ -749,7 +753,7 @@ describe("TranslateService", () =>
     translate.onLangChange.subscribe((event: LangChangeEvent) =>
     {
       expect(event.lang).toBe("en");
-      expect(event.translations).toEqual(tr);
+      expect(event.translations as any).toEqual(tr);
     });
     translate.use("en");
   });

--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { InterpolatableTranslationObject } from './translate.service';
+
 /**
  * Determines if two objects or two values are equivalent.
  *
@@ -50,29 +52,29 @@ export function equals(o1: any, o2: any): boolean {
   return false;
 }
 
-export function isDefinedAndNotNull(value: any): boolean {
+export function isDefinedAndNotNull<T>(value: T | null | undefined): value is T {
   return typeof value !== 'undefined' && value !== null;
 }
 
 
-export function isDict(value: any): boolean {
+export function isDict(value: any): value is InterpolatableTranslationObject {
   return isObject(value) && !isArray(value) && value !== null;
 }
 
 
-export function isObject(value: any): boolean {
+export function isObject(value: any): value is Record<string, any> {
   return typeof value === 'object';
 }
 
-export function isArray(value: any): boolean {
+export function isArray(value: any): value is any[] {
   return Array.isArray(value);
 }
 
-export function isString(value: any): boolean {
+export function isString(value: any): value is string {
   return typeof value === 'string';
 }
 
-export function isFunction(value: any):boolean {
+export function isFunction(value: any): boolean {
   return typeof value === "function"
 }
 
@@ -211,4 +213,3 @@ export function insertValue(target: Readonly<any>, key: string, value: any): any
 function createNestedObject(dotSeparatedKey: string, value: any): Record<string, any> {
   return dotSeparatedKey.split('.').reduceRight((acc, key) => ({ [key]: acc }), value);
 }
-


### PR DESCRIPTION
## Description
- **utils**: add function type inference
- **runInterpolation**: avoid null/undefined & refactor
- **InterpolatableTranslation**: remove any in favour of undefined & null
- Makes the required test changes

## Caution
I've tested it on my project and it seems to work, I'm not just I get all the different possibilities.  
Therefore I preferred to do a small PR, but maybe we could use a small `-rc` release with some testers

What about we create a more robust example inside the `test-app` folder, where we could really test out everything ? 
 