### PR TITLE
perf(http-loader): use of httpBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,34 +41,41 @@ Simple example using ngx-translate:
 https://stackblitz.com/github/ngx-translate/example
 
 ### Table of Contents
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Import the TranslateModule](#1-import-the-translatemodule)
-    * [SharedModule](#sharedmodule)
-    * [Lazy loaded modules](#lazy-loaded-modules)
-    * [Configuration](#configuration)
-    * [AoT](#aot)
-  * [Define the default language for the application](#2-define-the-default-language-for-the-application)
-  * [Init the TranslateService for your application](#3-init-the-translateservice-for-your-application)
-  * [Define the translations](#4-define-the-translations)
-  * [Use the service, the pipe or the directive](#5-use-the-service-the-pipe-or-the-directive)
-  * [Use HTML tags](#6-use-html-tags)
-* [API](#api)
-  * [TranslateService](#translateservice)
-    * [Properties](#properties)
-    * [Methods](#methods)
-    * [Write & use your own loader](#write--use-your-own-loader)
-      * [Example](#example)
-    * [How to use a compiler to preprocess translation values](#how-to-use-a-compiler-to-preprocess-translation-values)
-    * [How to handle missing translations](#how-to-handle-missing-translations)
-      * [Example](#example-1)
-  * [Parser](#parser)
-    * [Methods](#methods)
-* [FAQ](#faq)
-  * [I'm getting an error `npm ERR! peerinvalid Peer [...]`](#im-getting-an-error-npm-err-peerinvalid-peer-)
-* [Plugins](#plugins)
-* [Editors](#editors)
-* [Additional Framework Support](#additional-framework-support)
+- [@ngx-translate/core  ](#ngx-translatecore--)
+  - [Angular 16, 17, 18, 19+](#angular-16-17-18-19)
+  - [Angular \<=15](#angular-15)
+    - [Table of Contents](#table-of-contents)
+    - [Installation](#installation)
+    - [Usage](#usage)
+      - [1. Import the `TranslateModule`:](#1-import-the-translatemodule)
+        - [SharedModule](#sharedmodule)
+        - [Lazy loaded modules](#lazy-loaded-modules)
+        - [Configuration](#configuration)
+        - [AoT](#aot)
+      - [2. Define the `default language` for the application](#2-define-the-default-language-for-the-application)
+      - [3. Init the `TranslateService` for your application:](#3-init-the-translateservice-for-your-application)
+      - [4. Define the translations:](#4-define-the-translations)
+      - [5. Use the service, the pipe or the directive:](#5-use-the-service-the-pipe-or-the-directive)
+      - [6. Use HTML tags:](#6-use-html-tags)
+    - [API](#api)
+    - [TranslateService](#translateservice)
+      - [Properties:](#properties)
+      - [Methods:](#methods)
+      - [Write \& use your own loader](#write--use-your-own-loader)
+        - [Example](#example)
+      - [How to use a compiler to preprocess translation values](#how-to-use-a-compiler-to-preprocess-translation-values)
+      - [How to handle missing translations](#how-to-handle-missing-translations)
+        - [Example:](#example-1)
+    - [Parser](#parser)
+      - [Methods:](#methods-1)
+  - [FAQ](#faq)
+      - [I'm getting an error `npm ERR! peerinvalid Peer [...]`](#im-getting-an-error-npm-err-peerinvalid-peer-)
+      - [I want to hot reload the translations in my application but `reloadLang` does not work](#i-want-to-hot-reload-the-translations-in-my-application-but-reloadlang-does-not-work)
+  - [Plugins](#plugins)
+  - [Editors](#editors)
+    - [Extensions](#extensions)
+      - [VScode](#vscode)
+  - [Additional Framework Support](#additional-framework-support)
 
 
 ### Installation
@@ -170,7 +177,7 @@ export class LazyLoadedModule { }
 
 By default, there is no loader available. You can add translations manually using `setTranslation` but it is better to use a loader.
 You can write your own loader, or import an existing one.
-For example you can use the [`TranslateHttpLoader`](https://github.com/ngx-translate/http-loader) that will load translations from files using HttpClient.
+For example you can use the [`TranslateHttpLoader`](https://github.com/ngx-translate/http-loader) that will load translations from files using HttpBackend.
 
 To use it, you need to install the http-loader package from @ngx-translate:
 
@@ -185,14 +192,14 @@ Here is how you would use the `TranslateHttpLoader` to load translations from "/
 ```ts
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {HttpClientModule, HttpClient} from '@angular/common/http';
+import {HttpClientModule, HttpBackend} from '@angular/common/http';
 import {TranslateModule, TranslateLoader} from '@ngx-translate/core';
 import {TranslateHttpLoader} from '@ngx-translate/http-loader';
 import {AppComponent} from './app';
 
 // AoT requires an exported function for factories
-export function HttpLoaderFactory(http: HttpClient) {
-    return new TranslateHttpLoader(http);
+export function HttpLoaderFactory(httpBackend: HttpBackend) {
+    return new TranslateHttpLoader(httpBackend);
 }
 
 @NgModule({
@@ -203,7 +210,7 @@ export function HttpLoaderFactory(http: HttpClient) {
             loader: {
                 provide: TranslateLoader,
                 useFactory: HttpLoaderFactory,
-                deps: [HttpClient]
+                deps: [HttpBackend]
             }
         })
     ],
@@ -217,8 +224,8 @@ export class AppModule { }
 If you want to configure a custom `TranslateLoader` while using [AoT compilation](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html) or [Ionic](http://ionic.io/), you must use an exported function instead of an inline function.
 
 ```ts
-export function createTranslateLoader(http: HttpClient) {
-    return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+export function createTranslateLoader(httpBackend: HttpBackend) {
+    return new TranslateHttpLoader(httpBackend, './assets/i18n/', '.json');
 }
 
 @NgModule({
@@ -229,7 +236,7 @@ export function createTranslateLoader(http: HttpClient) {
             loader: {
                 provide: TranslateLoader,
                 useFactory: (createTranslateLoader),
-                deps: [HttpClient]
+                deps: [HttpBackend]
             }
         })
     ],

--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ npm install @ngx-translate/core --save
 Choose the version corresponding to your Angular version:
 
 
-| Angular       | @ngx-translate/core | @ngx-translate/http-loader | Tutorial | Docs |
-| ------------- | ------------------- | -------------------------- | -------- | ---- |
-| 16 - 19+ | 16.x | 16.x | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | https://ngx-translate.org |
-| 16 - 17+ | 16.x (15.x) | 16.x, (8.x) | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | https://ngx-translate.org/v15/ |
-| 13 - 15 (ivy only) | 14.x              | 7.x+ | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
-| 10 - 12   | 13.x               | 6.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
-| 9             | 12.x             | 5.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
-| 8             | 12.x             | 4.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
-| 7             | 11.x              | 4.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular7-app-with-ngx-translate) | here |
-| 6             | 10.x                | 3.x   | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular6-app-with-ngx-translate) | here |
+| Angular       | @ngx-translate/core | @ngx-translate/http-loader | Tutorial | Docs                                   |
+| ------------- | ------------------- | -------------------------- | -------- |----------------------------------------|
+| 16 - 19+ | 16.x | 16.x | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | [Docs](https://ngx-translate.org)      |
+| 16 - 17+ | 16.x (15.x) | 16.x, (8.x) | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | [Docs](https://ngx-translate.org/v15/) |
+| 13 - 15 (ivy only) | 14.x              | 7.x+ | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here                                   |
+| 10 - 12   | 13.x               | 6.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here                                   |
+| 9             | 12.x             | 5.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here                                   |
+| 8             | 12.x             | 4.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here                                   |
+| 7             | 11.x              | 4.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular7-app-with-ngx-translate) | here                                   |
+| 6             | 10.x                | 3.x   | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular6-app-with-ngx-translate) | here                                   |
 | 5             | 8.x to 9.x          | 1.x to 2.x | — |
 | 4.3           | 7.x or less         | 1.x to 2.x  | — |
 | 2 to 4.2.x    | 7.x or less         | 0.x  | — |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The internationalization (i18n) library for Angular.
 <br/>
 
-## Angular 16, 17, 18+
+## Angular 16, 17, 18, 19+
 
 The new [documentation](https://ngx-translate.org/) now covers installation on
 Angular 16+ and is divided into smaller, more readable sections, making it

--- a/README.md
+++ b/README.md
@@ -81,18 +81,20 @@ npm install @ngx-translate/core --save
 
 Choose the version corresponding to your Angular version:
 
- Angular       | @ngx-translate/core | @ngx-translate/http-loader
- ------------- |---------------------| --------------------------
- 16+           | 15.x+               | 8.x+
- 13+ (ivy only)| 14.x+               | 7.x+
- 10/11/12/13   | 13.x+               | 6.x+
- 9             | 12.x+               | 5.x+
- 8             | 12.x+               | 4.x+
- 7             | 11.x+               | 4.x+
- 6             | 10.x                | 3.x
- 5             | 8.x to 9.x          | 1.x to 2.x
- 4.3           | 7.x or less         | 1.x to 2.x
- 2 to 4.2.x    | 7.x or less         | 0.x
+
+| Angular       | @ngx-translate/core | @ngx-translate/http-loader | Tutorial | Docs |
+| ------------- | ------------------- | -------------------------- | -------- | ---- |
+| 16 - 19+ | 16.x | 16.x | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | https://ngx-translate.org |
+| 16 - 17+ | 16.x (15.x) | 16.x, (8.x) | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | https://ngx-translate.org/v15/ |
+| 13 - 15 (ivy only) | 14.x              | 7.x+ | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
+| 10 - 12   | 13.x               | 6.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
+| 9             | 12.x             | 5.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
+| 8             | 12.x             | 4.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate) | here |
+| 7             | 11.x              | 4.x+  | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular7-app-with-ngx-translate) | here |
+| 6             | 10.x                | 3.x   | [Tutorial](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular6-app-with-ngx-translate) | here |
+| 5             | 8.x to 9.x          | 1.x to 2.x | — |
+| 4.3           | 7.x or less         | 1.x to 2.x  | — |
+| 2 to 4.2.x    | 7.x or less         | 0.x  | — |
 
 
 ### Usage

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,7 +18,7 @@ module.exports = tseslint.config(
         "error",
         {
           type: "attribute",
-          prefix: "lib",
+          prefix: "app",
           style: "camelCase",
         },
       ],
@@ -26,7 +26,7 @@ module.exports = tseslint.config(
         "error",
         {
           type: "element",
-          prefix: "lib",
+          prefix: "app",
           style: "kebab-case",
         },
       ],

--- a/projects/http-loader/src/lib/http-loader.spec.ts
+++ b/projects/http-loader/src/lib/http-loader.spec.ts
@@ -1,8 +1,8 @@
-import {HttpClient, provideHttpClient} from "@angular/common/http";
-import {HttpTestingController, provideHttpClientTesting} from "@angular/common/http/testing";
-import {TestBed} from "@angular/core/testing";
-import {TranslateLoader, provideTranslateService, TranslateService, Translation} from "@ngx-translate/core";
-import {TranslateHttpLoader} from "../public-api";
+import { HttpBackend, provideHttpClient } from "@angular/common/http";
+import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+import { provideTranslateService, TranslateLoader, TranslateService, Translation } from "@ngx-translate/core";
+import { TranslateHttpLoader } from "../public-api";
 
 describe('TranslateLoader', () => {
   let translate: TranslateService;
@@ -17,8 +17,8 @@ describe('TranslateLoader', () => {
         provideTranslateService({
             loader: {
               provide: TranslateLoader,
-              useFactory: (httpClient: HttpClient) => new TranslateHttpLoader(httpClient),
-              deps: [HttpClient]
+              useFactory: (httpBackend: HttpBackend) => new TranslateHttpLoader(httpBackend),
+              deps: [HttpBackend]
             }
           }
         )

--- a/projects/http-loader/src/lib/http-loader.ts
+++ b/projects/http-loader/src/lib/http-loader.ts
@@ -1,12 +1,12 @@
-import {TranslateLoader, TranslationObject} from "@ngx-translate/core";
-import {HttpClient} from "@angular/common/http";
-import {Inject, Injectable} from "@angular/core";
-import {Observable} from 'rxjs';
+import { HttpBackend, HttpClient } from "@angular/common/http";
+import { Inject, Injectable } from "@angular/core";
+import { TranslateLoader, TranslationObject } from "@ngx-translate/core";
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class TranslateHttpLoader implements TranslateLoader {
   constructor(
-    private http: HttpClient,
+    private _handler: HttpBackend,
     @Inject(String) public prefix = "/assets/i18n/",
     @Inject(String) public suffix = ".json"
   )
@@ -16,6 +16,6 @@ export class TranslateHttpLoader implements TranslateLoader {
    * Gets the translations from the server
    */
   public getTranslation(lang: string): Observable<TranslationObject> {
-    return this.http.get(`${this.prefix}${lang}${this.suffix}`) as Observable<TranslationObject>;
+    return new HttpClient(this._handler).get(`${this.prefix}${lang}${this.suffix}`) as Observable<TranslationObject>;
   }
 }

--- a/projects/ngx-translate/eslint.config.js
+++ b/projects/ngx-translate/eslint.config.js
@@ -11,7 +11,7 @@ module.exports = tseslint.config(
         "error",
         {
           type: "attribute",
-          prefix: "lib",
+          prefix: "app",
           style: "camelCase",
         },
       ],
@@ -19,7 +19,7 @@ module.exports = tseslint.config(
         "error",
         {
           type: "element",
-          prefix: "lib",
+          prefix: "app",
           style: "kebab-case",
         },
       ],

--- a/projects/ngx-translate/package.json
+++ b/projects/ngx-translate/package.json
@@ -9,6 +9,13 @@
     "i18n",
     "translation"
   ],
+  "homepage": "https://github.com/ngx-translate/core#readme",
+  "bugs": {
+    "url": "https://github.com/ngx-translate/core/issues"
+  },
+  "repository": {
+    "url": "https://github.com/ngx-translate/core"
+  },
   "author": "Andreas Löw / CodeAndWeb GmbH, Olivier Combe",
   "license": "MIT",
   "peerDependencies": {

--- a/projects/ngx-translate/src/lib/translate.directive-module.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.directive-module.spec.ts
@@ -7,7 +7,7 @@ import {TranslateModule, TranslateService} from "../public-api";
 @Component({
   // eslint-disable-next-line @angular-eslint/prefer-standalone
   standalone: false,
-  selector: 'lib-hmx-app',
+  selector: 'app-hmx-app',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div #noKey translate>TEST</div>

--- a/projects/ngx-translate/src/lib/translate.directive-standalone.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.directive-standalone.spec.ts
@@ -4,7 +4,7 @@ import {provideTranslateService, TranslateDirective, TranslateService} from "../
 
 @Injectable()
 @Component({
-  selector: 'lib-hmx-app',
+  selector: 'app-hmx-app',
   standalone: true,
   imports: [TranslateDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/ngx-translate/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/src/lib/translate.directive.ts
@@ -141,7 +141,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
       };
 
       if (isDefined(translations)) {
-        const res = this.translateService.getParsedResult(translations as InterpolatableTranslation, key, this.currentParams);
+        const res = this.translateService.getParsedResult(key, this.currentParams);
         if (isObservable(res)) {
           res.subscribe({next: onTranslation});
         } else {

--- a/projects/ngx-translate/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/src/lib/translate.directive.ts
@@ -9,7 +9,7 @@ import {
   Translation,
   InterpolationParameters
 } from "./translate.service";
-import {equals, isDefined} from './util';
+import {equals, isDefinedAndNotNull} from './util';
 
 interface ExtendedNode extends Text {
   originalContent: string;
@@ -94,7 +94,7 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
         if (forceUpdate) {
           node.lastKey = null;
         }
-        if(isDefined(node.lookupKey)) {
+        if(isDefinedAndNotNull(node.lookupKey)) {
           key = node.lookupKey;
         } else if (this.key) {
           key = this.key;
@@ -134,13 +134,13 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
         if (!node.originalContent) {
           node.originalContent = this.getContent(node);
         }
-        node.currentValue = isDefined(res) ? res : (node.originalContent || key);
+        node.currentValue = isDefinedAndNotNull(res) ? res : (node.originalContent || key);
         // we replace in the original content to preserve spaces that we might have trimmed
         this.setContent(node, this.key ? node.currentValue : node.originalContent.replace(key, node.currentValue));
         this._ref.markForCheck();
       };
 
-      if (isDefined(translations)) {
+      if (isDefinedAndNotNull(translations)) {
         const res = this.translateService.getParsedResult(key, this.currentParams);
         if (isObservable(res)) {
           res.subscribe({next: onTranslation});
@@ -154,11 +154,11 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
   }
 
   getContent(node: ExtendedNode): string {
-    return (isDefined(node.textContent) ? node.textContent : node.data) as string;
+    return (isDefinedAndNotNull(node.textContent) ? node.textContent : node.data) as string;
   }
 
   setContent(node: ExtendedNode, content: string): void {
-    if (isDefined(node.textContent)) {
+    if (isDefinedAndNotNull(node.textContent)) {
       node.textContent = content;
     } else {
       node.data = content;

--- a/projects/ngx-translate/src/lib/translate.loader.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.loader.spec.ts
@@ -88,11 +88,7 @@ describe('TranslateLoader', () => {
     expect(translate.currentLoader).toBeDefined();
     expect(translate.currentLoader instanceof TranslateFakeLoader).toBeTruthy();
 
-    // the lang to use, if the lang isn't available, it will use the current loader to get them
-    translate.use('en');
-
-    // this will request the translation from the backend because we use a static files loader for TranslateService
-    translate.getTranslation('en').subscribe((res: Translation) => {
+    translate.use('en').subscribe((res: Translation) => {
       expect(res).toEqual({});
     });
   });

--- a/projects/ngx-translate/src/lib/translate.parser.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.parser.spec.ts
@@ -35,7 +35,7 @@ describe('Parser', () => {
     });
 
     it('should handle edge cases: array', () => {
-      expect(parser.interpolate("This is an array {{ key1.key2 }}", {key1: {key2: ['A', 'B', 'C']}})).toEqual("This is an array A,B,C");
+      expect(parser.interpolate("This is an array {{ key1.key2 }}", {key1: {key2: ['A', 'B', 'C']}})).toEqual("This is an array A, B, C");
     });
 
     it('should handle edge cases: bool', () => {
@@ -43,10 +43,10 @@ describe('Parser', () => {
     });
 
     it('should handle edge cases: object', () => {
-      expect(parser.interpolate("This is a {{ key1.key2 }}", {key1: {key2: {key3: "value3"}}})).toEqual("This is a [object Object]");
+      expect(parser.interpolate("Object value: {{ key1.key2 }}", {key1: {key2: {key3: "value3"}}})).toEqual("Object value: {\"key3\":\"value3\"}");
     });
 
-    it('should handle edge cases: object', () => {
+    it('should handle edge cases: object with custom toString', () => {
       const object = {
         toString: () => "OBJECT A"
       }

--- a/projects/ngx-translate/src/lib/translate.parser.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.parser.spec.ts
@@ -34,8 +34,16 @@ describe('Parser', () => {
       expect(parser.interpolate( uc , {"x":'bless'})).toBe('BLESS YOU!');
     });
 
+    it('should handle edge cases: value not found', () => {
+      expect(parser.interpolate("This is an array {{ key1.key2 }}", {key1: {key3: ['A', 'B', 'C']}})).toEqual("This is an array {{ key1.key2 }}");
+    });
+
     it('should handle edge cases: array', () => {
       expect(parser.interpolate("This is an array {{ key1.key2 }}", {key1: {key2: ['A', 'B', 'C']}})).toEqual("This is an array A, B, C");
+    });
+
+    it('should handle edge cases: null', () => {
+      expect(parser.interpolate("This is {{ key1.key2 }}", {key1: {key2: null}})).toEqual("This is null");
     });
 
     it('should handle edge cases: bool', () => {

--- a/projects/ngx-translate/src/lib/translate.parser.ts
+++ b/projects/ngx-translate/src/lib/translate.parser.ts
@@ -48,9 +48,10 @@ export class TranslateDefaultParser extends TranslateParser
       return expr;
     }
 
-    return expr.replace(this.templateMatcher, (_substring: string, key: string) =>
+    return expr.replace(this.templateMatcher, (substring: string, key: string) =>
     {
-      return this.getInterpolationReplacement(params, key);
+      const replacement = this.getInterpolationReplacement(params, key);
+      return replacement !== undefined ? replacement : substring;
     });
   }
 
@@ -58,19 +59,18 @@ export class TranslateDefaultParser extends TranslateParser
    * Returns the replacement for an interpolation parameter
    * @params:
    */
-  protected getInterpolationReplacement(params: InterpolationParameters, key: string): string
+  protected getInterpolationReplacement(params: InterpolationParameters, key: string): string|undefined
   {
-    return this.formatValue(getValue(params, key), key);
+    return this.formatValue(getValue(params, key));
   }
 
   /**
    * Converts a value into a useful string representation.
    * @param value The value to format.
-   * @param fallback the value to return in case value is undefined
    * @returns A string representation of the value.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected formatValue(value: any, fallback:string): string
+  protected formatValue(value: any): string|undefined
   {
     if (isString(value)) {
       return value;
@@ -93,6 +93,6 @@ export class TranslateDefaultParser extends TranslateParser
       return JSON.stringify(value); // Pretty-print JSON if no meaningful toString()
     }
 
-    return fallback;
+    return undefined;
   }
 }

--- a/projects/ngx-translate/src/lib/translate.pipe-modules.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe-modules.spec.ts
@@ -37,7 +37,7 @@ class FakeChangeDetectorRef extends ChangeDetectorRef {
 @Component({
   // eslint-disable-next-line @angular-eslint/prefer-standalone
   standalone: false,
-  selector: 'lib-hmx-app',
+  selector: 'app-hmx-app',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `{{'TEST' | translate}}`
 })

--- a/projects/ngx-translate/src/lib/translate.pipe-standalone.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe-standalone.spec.ts
@@ -42,7 +42,7 @@ class FakeChangeDetectorRef extends ChangeDetectorRef {
 
 @Injectable()
 @Component({
-  selector: 'lib-hmx-app',
+  selector: 'app-hmx-app',
   standalone: true,
   imports: [TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -59,7 +59,7 @@ class AppTranslationIdDefaultComponent {
 
 @Injectable()
 @Component({
-  selector: 'lib-hmx-app',
+  selector: 'app-hmx-app',
   standalone: true,
   imports: [TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/ngx-translate/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe.ts
@@ -34,7 +34,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
       this._ref.markForCheck();
     };
     if (translations) {
-      const res = this.translate.getParsedResult(translations, key, interpolateParams);
+      const res = this.translate.getParsedResult(key, interpolateParams);
       if (isObservable(res)) {
         res.subscribe(onTranslation);
       } else {

--- a/projects/ngx-translate/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe.ts
@@ -8,7 +8,7 @@ import {
   Translation,
   InterpolationParameters
 } from "./translate.service";
-import {equals, isDefined, isDict, isString} from "./util";
+import {equals, isDefinedAndNotNull, isDict, isString} from "./util";
 
 @Injectable()
 @Pipe({
@@ -56,7 +56,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     }
 
     let interpolateParams: object | undefined = undefined;
-    if (isDefined(args[0]) && args.length) {
+    if (isDefinedAndNotNull(args[0]) && args.length) {
       if (isString(args[0]) && args[0].length) {
         // we accept objects written in the template such as {n:1}, {'n':1}, {n:'v'}
         // which is why we might need to change it to real JSON objects such as {"n":1} or {"n":"v"}

--- a/projects/ngx-translate/src/lib/translate.service.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.service.spec.ts
@@ -1103,7 +1103,7 @@ describe('TranslateService (isolate)', () => {
 
   @Component({
     standalone: true,
-    selector: "lib-isolated-child",
+    selector: "app-isolated-child",
     template: `
       <div class="isolated-child">{{ 'test' | translate }}</div>
     `,
@@ -1130,7 +1130,7 @@ describe('TranslateService (isolate)', () => {
 
   @Component({
     standalone: true,
-    selector: "lib-shared-child",
+    selector: "app-shared-child",
     template: `
       <div class="shared-child">{{ 'test' | translate }}</div>
     `,
@@ -1148,11 +1148,11 @@ describe('TranslateService (isolate)', () => {
   @Component({
     standalone: true,
     imports: [RouterOutlet, IsolatedChildComponent, SharedChildComponent, TranslatePipe],
-    selector: "lib-test",
+    selector: "app-test",
     template: `
       <div class="root">{{ 'test' | translate }}</div>
-      <lib-isolated-child/>
-      <lib-shared-child/>
+      <app-isolated-child/>
+      <app-shared-child/>
     `
   })
   class AppTestComponent {

--- a/projects/ngx-translate/src/lib/translate.service.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.service.spec.ts
@@ -799,24 +799,18 @@ describe("TranslateService", () =>
   it("should be able to add new languages", () =>
   {
     translate.addLangs(["pl", "es"]);
-    expect(translate.getLangs()).toEqual(["pl", "es"]);
+    expect(translate.langs).toEqual(["pl", "es"]);
     translate.addLangs(["fr"]);
     translate.addLangs(["pl", "fr"]);
-    expect(translate.getLangs()).toEqual(["pl", "es", "fr"]);
+    expect(translate.langs).toEqual(["pl", "es", "fr"]);
 
     // this will request the translation from the backend because we use a static files loader for TranslateService
     translate.use("en").subscribe(() =>
     {
-      expect(translate.getLangs()).toEqual(["pl", "es", "fr", "en"]);
+      expect(translate.langs).toEqual(["pl", "es", "fr", "en"]);
       translate.addLangs(["de"]);
-      expect(translate.getLangs()).toEqual(["pl", "es", "fr", "en", "de"]);
+      expect(translate.langs).toEqual(["pl", "es", "fr", "en", "de"]);
     });
-  });
-
-  it("should be able to set the langs property directly", () =>
-  {
-    translate.langs = ["pl", "es"];
-    expect(translate.getLangs()).toEqual(["pl", "es"]);
   });
 
   it("should be able to get the browserLang", () =>

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -290,21 +290,6 @@ export class TranslateService {
   }
 
 
-
-  /**
-   * Gets an object of translations for a given language with the current loader
-   * and passes it through the compiler
-   *
-   * @deprecated This function is meant for internal use. There should
-   * be no reason to use outside this service. You can plug into this
-   * functionality by using a customer TranslateLoader or TranslateCompiler.
-   * To load a new language use setDefaultLang() and/or use()
-   */
-  public getTranslation(lang: string): Observable<InterpolatableTranslationObject>
-  {
-      return this.loadAndCompileTranslations(lang);
-  }
-
   private loadAndCompileTranslations(lang: string): Observable<InterpolatableTranslationObject> {
 
     this.pending = true;

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -343,9 +343,9 @@ export class TranslateService {
   }
 
 
-  private getParsedResultForKey(translations: InterpolatableTranslation, key: string, interpolateParams?: InterpolationParameters): Translation|Observable<Translation>
+  private getParsedResultForKey(key: string, interpolateParams?: InterpolationParameters): Translation|Observable<Translation>
   {
-      const textToInterpolate = this.getTextToInterpolate(translations, key);
+      const textToInterpolate = this.getTextToInterpolate(key);
 
       let res: Translation | undefined;
 
@@ -365,9 +365,9 @@ export class TranslateService {
       return res !== undefined ? res : key;
   }
 
-  private getTextToInterpolate(translations: InterpolatableTranslation, key: string): InterpolatableTranslation | undefined
+  private getTextToInterpolate(key: string): InterpolatableTranslation | undefined
   {
-      let text = getValue(translations, key);
+      let text = getValue(this.store.getTranslations(this.currentLang), key);
       if(text === undefined && this.defaultLang != null && this.defaultLang !== this.currentLang && this.useDefaultLang)
       {
           text = getValue(this.store.getTranslations(this.defaultLang), key);
@@ -402,7 +402,7 @@ export class TranslateService {
   /**
    * Returns the parsed result of the translations
    */
-  public getParsedResult(translations: InterpolatableTranslation, key: string | string[], interpolateParams?: InterpolationParameters): Translation|TranslationObject|Observable<Translation|TranslationObject> {
+  public getParsedResult(key: string | string[], interpolateParams?: InterpolationParameters): Translation|TranslationObject|Observable<Translation|TranslationObject> {
 
     // handle a bunch of keys
     if (key instanceof Array) {
@@ -410,7 +410,7 @@ export class TranslateService {
 
       let observables = false;
       for (const k of key) {
-        result[k] = this.getParsedResultForKey(translations, k, interpolateParams);
+        result[k] = this.getParsedResultForKey(k, interpolateParams);
         observables = observables || isObservable(result[k]);
       }
 
@@ -430,7 +430,7 @@ export class TranslateService {
       );
     }
 
-    return this.getParsedResultForKey(translations, key, interpolateParams);
+    return this.getParsedResultForKey(key, interpolateParams);
   }
 
   /**
@@ -445,12 +445,12 @@ export class TranslateService {
     if (this.pending) {
       return this.loadingTranslations.pipe(
         concatMap((res: InterpolatableTranslation) => {
-          return makeObservable(this.getParsedResult(res, key, interpolateParams));
+          return makeObservable(this.getParsedResult(key, interpolateParams));
         }),
       );
     }
 
-    return makeObservable(this.getParsedResult(this.store.getTranslations(this.currentLang), key, interpolateParams));
+    return makeObservable(this.getParsedResult(key, interpolateParams));
   }
 
   /**
@@ -467,7 +467,7 @@ export class TranslateService {
       defer(() => this.get(key, interpolateParams)),
       this.onTranslationChange.pipe(
         switchMap((event: TranslationChangeEvent) => {
-          const res = this.getParsedResult(event.translations, key, interpolateParams);
+          const res = this.getParsedResult(key, interpolateParams);
           return makeObservable(res);
         })
       )
@@ -488,7 +488,7 @@ export class TranslateService {
       defer(() => this.get(key, interpolateParams)),
       this.onLangChange.pipe(
         switchMap((event: LangChangeEvent) => {
-          const res = this.getParsedResult(event.translations, key, interpolateParams);
+          const res = this.getParsedResult(key, interpolateParams);
           return makeObservable(res);
         })
       ));
@@ -505,7 +505,7 @@ export class TranslateService {
       throw new Error('Parameter "key" is required and cannot be empty');
     }
 
-    const result = this.getParsedResult(this.store.getTranslations(this.currentLang), key, interpolateParams);
+    const result = this.getParsedResult(key, interpolateParams);
 
     if (isObservable(result)) {
       if (Array.isArray(key)) {

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -1,4 +1,4 @@
-import {EventEmitter, Inject, Injectable, InjectionToken} from "@angular/core";
+import {Inject, Injectable, InjectionToken} from "@angular/core";
 import {concat, forkJoin, isObservable, Observable, of, defer} from "rxjs";
 import {concatMap, map, shareReplay, switchMap, take} from "rxjs/operators";
 import {MissingTranslationHandler, MissingTranslationHandlerParams} from "./missing-translation-handler";
@@ -96,32 +96,32 @@ export class TranslateService {
 
 
   /**
-   * An EventEmitter to listen to translation change events
+   * An Observable to listen to translation change events
    * onTranslationChange.subscribe((params: TranslationChangeEvent) => {
      *     // do something
      * });
    */
-  get onTranslationChange(): EventEmitter<TranslationChangeEvent> {
+  get onTranslationChange(): Observable<TranslationChangeEvent> {
     return this.store.onTranslationChange;
   }
 
   /**
-   * An EventEmitter to listen to lang change events
+   * An Observable to listen to lang change events
    * onLangChange.subscribe((params: LangChangeEvent) => {
      *     // do something
      * });
    */
-  get onLangChange(): EventEmitter<LangChangeEvent> {
+  get onLangChange(): Observable<LangChangeEvent> {
     return this.store.onLangChange;
   }
 
   /**
-   * An EventEmitter to listen to default lang change events
+   * An Observable to listen to default lang change events
    * onDefaultLangChange.subscribe((params: DefaultLangChangeEvent) => {
      *     // do something
      * });
    */
-  get onDefaultLangChange() {
+  get onDefaultLangChange(): Observable<DefaultLangChangeEvent> {
     return this.store.onDefaultLangChange;
   }
 
@@ -287,7 +287,7 @@ export class TranslateService {
 
     this.currentLang = lang;
 
-    this.onLangChange.emit({lang: lang, translations: this.translations[lang]});
+    this.store.emitLangChange({lang: lang, translations: this.translations[lang]});
 
     // if there is no default lang, use the one that we just set
     if (this.defaultLang == null) {
@@ -369,7 +369,7 @@ export class TranslateService {
       this.translations[lang] = interpolatableTranslations;
     }
     this.updateLangs();
-    this.onTranslationChange.emit({lang: lang, translations: this.translations[lang]});
+    this.store.emitTranslationChange({lang: lang, translations: this.translations[lang]});
   }
 
   /**
@@ -584,7 +584,7 @@ export class TranslateService {
       : this.compiler.compileTranslations(translation, lang)
     );
     this.updateLangs();
-    this.onTranslationChange.emit({lang: lang, translations: this.translations[lang]});
+    this.store.emitTranslationChange({lang: lang, translations: this.translations[lang]});
   }
 
   /**
@@ -592,7 +592,7 @@ export class TranslateService {
    */
   private changeDefaultLang(lang: string): void {
     this.defaultLang = lang;
-    this.onDefaultLangChange.emit({lang: lang, translations: this.translations[lang]});
+    this.store.emitDefaultLangChange({lang: lang, translations: this.translations[lang]});
   }
 
   /**

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -6,7 +6,7 @@ import {TranslateCompiler} from "./translate.compiler";
 import {TranslateLoader} from "./translate.loader";
 import {InterpolateFunction, TranslateParser} from "./translate.parser";
 import {TranslateStore} from "./translate.store";
-import {getValue, isDefined, isArray, isString, setValue, isDict, insertValue} from "./util";
+import {isDefined, isArray, isString, isDict, insertValue} from "./util";
 
 export const ISOLATE_TRANSLATE_SERVICE = new InjectionToken<string>('ISOLATE_TRANSLATE_SERVICE');
 export const USE_DEFAULT_LANG = new InjectionToken<string>('USE_DEFAULT_LANG');
@@ -367,12 +367,7 @@ export class TranslateService {
 
   private getTextToInterpolate(key: string): InterpolatableTranslation | undefined
   {
-      let text = getValue(this.store.getTranslations(this.currentLang), key);
-      if(text === undefined && this.defaultLang != null && this.defaultLang !== this.currentLang && this.useDefaultLang)
-      {
-          text = getValue(this.store.getTranslations(this.defaultLang), key);
-      }
-      return text;
+    return this.store.getTranslation(key, this.useDefaultLang);
   }
 
   private runInterpolation(translations: InterpolatableTranslation, interpolateParams?: InterpolationParameters): Translation
@@ -444,7 +439,7 @@ export class TranslateService {
     // check if we are loading a new translation to use
     if (this.pending) {
       return this.loadingTranslations.pipe(
-        concatMap((res: InterpolatableTranslation) => {
+        concatMap(() => {
           return makeObservable(this.getParsedResult(key, interpolateParams));
         }),
       );
@@ -466,7 +461,7 @@ export class TranslateService {
     return concat(
       defer(() => this.get(key, interpolateParams)),
       this.onTranslationChange.pipe(
-        switchMap((event: TranslationChangeEvent) => {
+        switchMap(() => {
           const res = this.getParsedResult(key, interpolateParams);
           return makeObservable(res);
         })
@@ -487,7 +482,7 @@ export class TranslateService {
     return concat(
       defer(() => this.get(key, interpolateParams)),
       this.onLangChange.pipe(
-        switchMap((event: LangChangeEvent) => {
+        switchMap(() => {
           const res = this.getParsedResult(key, interpolateParams);
           return makeObservable(res);
         })

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -399,25 +399,34 @@ export class TranslateService {
 
   private getParsedResultForKey(translations: InterpolatableTranslation, key: string, interpolateParams?: InterpolationParameters): Translation|Observable<Translation>
   {
-      let res: Translation | Observable<Translation> | undefined;
+      const textToInterpolate = this.getTextToInterpolate(translations, key);
 
-      if (translations) {
-        res = this.runInterpolation(getValue(translations, key), interpolateParams);
+      let res: Translation | undefined;
+
+      if (textToInterpolate !== undefined)
+      {
+          res = this.runInterpolation(textToInterpolate, interpolateParams);
       }
-
-      if (res === undefined && this.defaultLang != null && this.defaultLang !== this.currentLang && this.useDefaultLang) {
-        res = this.runInterpolation(getValue(this.translations[this.defaultLang], key), interpolateParams);
-      }
-
-      if (res === undefined) {
-        const params: MissingTranslationHandlerParams = {key, translateService: this};
-        if (typeof interpolateParams !== 'undefined') {
-          params.interpolateParams = interpolateParams;
-        }
-        res = this.missingTranslationHandler.handle(params);
+      else
+      {
+          const params: MissingTranslationHandlerParams = {key, translateService: this};
+          if (typeof interpolateParams !== 'undefined') {
+              params.interpolateParams = interpolateParams;
+          }
+          res = this.missingTranslationHandler.handle(params);
       }
 
       return res !== undefined ? res : key;
+  }
+
+  private getTextToInterpolate(translations: InterpolatableTranslation, key: string): InterpolatableTranslation | undefined
+  {
+      let text = getValue(translations, key);
+      if(text === undefined && this.defaultLang != null && this.defaultLang !== this.currentLang && this.useDefaultLang)
+      {
+          text = getValue(this.translations[this.defaultLang], key);
+      }
+      return text;
   }
 
   private runInterpolation(translations: InterpolatableTranslation, interpolateParams?: InterpolationParameters): Translation

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -184,12 +184,12 @@ export class TranslateService {
    */
   public setDefaultLang(lang: string): Observable<InterpolatableTranslationObject>
   {
-    if (this.defaultLang == null)
+    if (!this.defaultLang)
     {
       // on init set the defaultLang immediately, but do not emit a change yet
       this.store.setDefaultLang(lang, false);
     }
-
+    
     const pending = this.loadOrExtendLanguage(lang);
     if (isObservable(pending))
     {

--- a/projects/ngx-translate/src/lib/translate.store.spec.ts
+++ b/projects/ngx-translate/src/lib/translate.store.spec.ts
@@ -7,7 +7,7 @@ import {TranslateModule, TranslateService} from"../public-api";
 @Component({
   // eslint-disable-next-line @angular-eslint/prefer-standalone
   standalone: false,
-  selector: 'lib-root-cmp',
+  selector: 'app-root-cmp',
   template: `
       <router-outlet></router-outlet>`
 })
@@ -24,7 +24,7 @@ class RootComponent {
 @Component({
   // eslint-disable-next-line @angular-eslint/prefer-standalone
   standalone: false,
-  selector: 'lib-lazy',
+  selector: 'app-lazy',
   template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
 })
 class ParentLazyLoadedComponent {
@@ -32,7 +32,7 @@ class ParentLazyLoadedComponent {
 
 function getLazyLoadedModule<T extends object>(importedModule: ModuleWithProviders<T>) {
   // eslint-disable-next-line @angular-eslint/prefer-standalone
-  @Component({selector: 'lib-lazy', template: 'lazy-loaded-child', standalone: false})
+  @Component({selector: 'app-lazy', template: 'lazy-loaded-child', standalone: false})
   class ChildLazyLoadedComponent {
     constructor(public translate: TranslateService) {
       translate.setTranslation('en', {

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -106,13 +106,6 @@ export class TranslateStore
         return this._onDefaultLangChange.asObservable();
     }
 
-    /**
-     * Update the list of available languages
-     */
-    public updateLanguages(): void {
-        this.addLanguages(Object.keys(this.translations));
-    }
-
     public addLanguages(languages: Language[]): void
     {
         this.languages = Array.from(new Set([...this.languages, ...languages]));

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,53 +1,84 @@
-import {EventEmitter} from "@angular/core";
 import {
-  InterpolatableTranslationObject,
-  DefaultLangChangeEvent,
-  LangChangeEvent,
-  TranslationChangeEvent
+    InterpolatableTranslationObject,
+    DefaultLangChangeEvent,
+    LangChangeEvent,
+    TranslationChangeEvent
 } from "./translate.service";
+import {Observable, Subject} from "rxjs";
 
-export class TranslateStore {
-  /**
-   * The default lang to fallback when translations are missing on the current lang
-   */
-  public defaultLang!: string;
 
-  /**
-   * The lang currently used
-   */
-  public currentLang: string = this.defaultLang;
+export class TranslateStore
+{
+    private _onTranslationChange: Subject<TranslationChangeEvent> = new Subject<TranslationChangeEvent>();
+    private _onLangChange: Subject<LangChangeEvent> = new Subject<LangChangeEvent>();
+    private _onDefaultLangChange: Subject<DefaultLangChangeEvent> = new Subject<DefaultLangChangeEvent>();
 
-  /**
-   * a list of translations per lang
-   */
-  public translations: Record<string, InterpolatableTranslationObject> = {};
 
-  /**
-   * an array of langs
-   */
-  public langs: string[] = [];
+    /**
+     * The default lang to fallback when translations are missing on the current lang
+     */
+    public defaultLang!: string;
 
-  /**
-   * An EventEmitter to listen to translation change events
-   * onTranslationChange.subscribe((params: TranslationChangeEvent) => {
+    /**
+     * The lang currently used
+     */
+    public currentLang: string = this.defaultLang;
+
+    /**
+     * a list of translations per lang
+     */
+    public translations: Record<string, InterpolatableTranslationObject> = {};
+
+    /**
+     * an array of langs
+     */
+    public langs: string[] = [];
+
+    /**
+     * An Observable to listen to translation change events
+     * onTranslationChange.subscribe((params: TranslationChangeEvent) => {
      *     // do something
      * });
-   */
-  public onTranslationChange: EventEmitter<TranslationChangeEvent> = new EventEmitter<TranslationChangeEvent>();
+     */
+    get onTranslationChange(): Observable<TranslationChangeEvent>
+    {
+        return this._onTranslationChange.asObservable();
+    }
 
-  /**
-   * An EventEmitter to listen to lang change events
-   * onLangChange.subscribe((params: LangChangeEvent) => {
+    public emitTranslationChange(event:TranslationChangeEvent): void
+    {
+        this._onTranslationChange.next(event);
+    }
+
+    /**
+     * An Observable to listen to lang change events
+     * onLangChange.subscribe((params: LangChangeEvent) => {
      *     // do something
      * });
-   */
-  public onLangChange: EventEmitter<LangChangeEvent> = new EventEmitter<LangChangeEvent>();
+     */
+    get onLangChange(): Observable<LangChangeEvent>
+    {
+        return this._onLangChange.asObservable();
+    }
 
-  /**
-   * An EventEmitter to listen to default lang change events
-   * onDefaultLangChange.subscribe((params: DefaultLangChangeEvent) => {
+    public emitLangChange(event:LangChangeEvent): void
+    {
+        this._onLangChange.next(event);
+    }
+
+    /**
+     * An Observable to listen to default lang change events
+     * onDefaultLangChange.subscribe((params: DefaultLangChangeEvent) => {
      *     // do something
      * });
-   */
-  public onDefaultLangChange: EventEmitter<DefaultLangChangeEvent> = new EventEmitter<DefaultLangChangeEvent>();
+     */
+    get onDefaultLangChange(): Observable<DefaultLangChangeEvent>
+    {
+        return this._onDefaultLangChange.asObservable();
+    }
+
+    public emitDefaultLangChange(event:DefaultLangChangeEvent): void
+    {
+        this._onDefaultLangChange.next(event);
+    }
 }

--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -50,7 +50,7 @@ export function equals(o1: any, o2: any): boolean {
   return false;
 }
 
-export function isDefined(value: any): boolean {
+export function isDefinedAndNotNull(value: any): boolean {
   return typeof value !== 'undefined' && value !== null;
 }
 
@@ -142,8 +142,8 @@ export function getValue(target: any, key: string): any
   {
     key += keys.shift();
     if (
-      isDefined(target) &&
-      (isDefined(target[key]) || target[key] === null) &&
+      isDefinedAndNotNull(target) &&
+      (isDefinedAndNotNull(target[key]) || target[key] === null) &&
       (isDict(target[key]) || isArray(target[key]) || !keys.length)
     )
     {

--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -102,10 +102,16 @@ export function mergeDeep(target: any, source: any): any {
 
 
 /**
- * Gets a value from an object by composed key
- * getValue({ key1: { keyA: 'valueI' }}, 'key1.keyA') ==> 'valueI'
- * @param target
- * @param key
+ * Retrieves a value from a nested object using a dot-separated key path.
+ *
+ * Example usage:
+ * ```ts
+ * getValue({ key1: { keyA: 'valueI' }}, 'key1.keyA'); // returns 'valueI'
+ * ```
+ *
+ * @param target The source object from which to retrieve the value.
+ * @param key Dot-separated key path specifying the value to retrieve.
+ * @returns The value at the specified key path, or `undefined` if not found.
  */
 export function getValue(target: any, key: string): any
 {

--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -76,12 +76,32 @@ export function isFunction(value: any):boolean {
   return typeof value === "function"
 }
 
+export function cloneDeep<T>(obj: Readonly<T>): T
+{
+  if (obj === null || typeof obj !== "object")
+  {
+    return obj;
+  }
 
-export function mergeDeep(target: any, source: any): any {
-  const output = Object.assign({}, target);
+  if (Array.isArray(obj)) {
+    return obj.map((item) => cloneDeep(item)) as unknown as T;
+  }
 
-  if (!isObject(target)) {
-    return mergeDeep({}, source);
+  const clonedObj: Record<string, any> = {};
+
+  Object.keys(obj).forEach((key) => {
+    clonedObj[key] = cloneDeep((obj as Record<string, any>)[key]);
+  });
+
+  return clonedObj as T;
+}
+
+export function mergeDeep(target: Readonly<any>, source: any): any {
+  const output = cloneDeep(target);
+
+  if (!isObject(target))
+  {
+    return cloneDeep(source)
   }
 
   if (isObject(target) && isObject(source)) {
@@ -140,11 +160,13 @@ export function getValue(target: any, key: string): any
 }
 
 /**
- * Gets a value from an object by composed key
+ * Sets a value on object using a dot separated key.
+ * This function modifies the object in place
  * parser.setValue({a:{b:{c: "test"}}}, 'a.b.c', "test2") ==> {a:{b:{c: "test2"}}}
  * @param target an object
  * @param key E.g. "a.b.c"
  * @param value to set
+ * @deprecated use insertValue() instead
  */
 export function setValue(target: any, key: string, value: any): void {
   const keys = key.split('.');
@@ -166,4 +188,23 @@ export function setValue(target: any, key: string, value: any): void {
   }
 }
 
+
+
+/**
+ * Sets a value on object using a dot separated key.
+ * Returns a clone of the object without modifying it
+ * parser.setValue({a:{b:{c: "test"}}}, 'a.b.c', "test2") ==> {a:{b:{c: "test2"}}}
+ * @param target an object
+ * @param key E.g. "a.b.c"
+ * @param value to set
+ */
+export function insertValue(target: Readonly<any>, key: string, value: any): any {
+  return mergeDeep(target, createNestedObject(key, value));
+}
+
+
+
+function createNestedObject(dotSeparatedKey: string, value: any): Record<string, any> {
+  return dotSeparatedKey.split('.').reduceRight((acc, key) => ({ [key]: acc }), value);
+}
 

--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -141,7 +141,11 @@ export function getValue(target: any, key: string): any
   do
   {
     key += keys.shift();
-    if (isDefined(target) && isDefined(target[key]) && (isDict(target[key]) ||isArray(target[key]) || !keys.length))
+    if (
+      isDefined(target) &&
+      (isDefined(target[key]) || target[key] === null) &&
+      (isDict(target[key]) || isArray(target[key]) || !keys.length)
+    )
     {
       target = target[key];
       key = "";

--- a/projects/test-app/src/app/app.component.ts
+++ b/projects/test-app/src/app/app.component.ts
@@ -1,14 +1,12 @@
-import {Component} from "@angular/core";
-import {RouterOutlet} from "@angular/router";
-import {TranslateService, TranslatePipe, TranslateDirective} from "@ngx-translate/core";
-import {StandaloneComponent} from "./standalone.component";
-import {_} from "@ngx-translate/core";
+import { Component } from "@angular/core";
+import { _, TranslateDirective, TranslatePipe, TranslateService } from "@ngx-translate/core";
+import { StandaloneComponent } from "./standalone.component";
 
 
 @Component({
     selector: "app-root",
     standalone: true,
-    imports: [RouterOutlet, TranslateDirective, TranslatePipe, StandaloneComponent],
+    imports: [TranslateDirective, TranslatePipe, StandaloneComponent],
     templateUrl: "./app.component.html",
     styleUrl: "./app.component.scss"
 })

--- a/projects/test-app/src/app/app.config.ts
+++ b/projects/test-app/src/app/app.config.ts
@@ -1,13 +1,13 @@
-import {ApplicationConfig, provideZoneChangeDetection} from "@angular/core";
-import {provideRouter} from "@angular/router";
+import { ApplicationConfig, provideZoneChangeDetection } from "@angular/core";
+import { provideRouter } from "@angular/router";
 
-import {routes} from "./app.routes";
-import {HttpClient, provideHttpClient} from "@angular/common/http";
-import {TranslateLoader, provideTranslateService} from "@ngx-translate/core";
-import {TranslateHttpLoader} from "@ngx-translate/http-loader";
+import { HttpBackend, provideHttpClient } from "@angular/common/http";
+import { TranslateLoader, provideTranslateService } from "@ngx-translate/core";
+import { TranslateHttpLoader } from "@ngx-translate/http-loader";
+import { routes } from "./app.routes";
 
-const httpLoaderFactory: (http: HttpClient) => TranslateHttpLoader = (http: HttpClient) =>
-  new TranslateHttpLoader(http, "./i18n/", ".json");
+const httpLoaderFactory: (_httpBackend: HttpBackend) => TranslateHttpLoader = (_httpBackend: HttpBackend) =>
+  new TranslateHttpLoader(_httpBackend, "./i18n/", ".json");
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -18,7 +18,7 @@ export const appConfig: ApplicationConfig = {
             loader: {
                 provide: TranslateLoader,
                 useFactory: httpLoaderFactory,
-                deps: [HttpClient]
+                deps: [HttpBackend]
             }
         })
     ]


### PR DESCRIPTION
## Description
The http-loader library is using the `httpClient`.  
I would recommend using the `httpBackend`, as it does not get catch by the interceptors.  

This solves several issues in which the `in18` files would load after the website get rendered, which decrease the user experience and can cause some "unexpected errors".

I'm using it in the [ngx-translate-multi-http-laoder](https://www.npmjs.com/package/ngx-translate-multi-http-loader) library for over two years and never got any bug report. So it can be consider stable. 

Solves: 
- https://github.com/ngx-translate/core/issues/1312
- https://github.com/ngx-translate/core/issues/1471

May also solves
- https://github.com/ngx-translate/core/issues/1258
