### PR TITLE
Revert "Add fast exit if no params provided"

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -327,14 +327,10 @@ export class TranslateService {
   private getParsedResultForKey(key: string, interpolateParams?: InterpolationParameters): Translation|Observable<Translation>
   {
       const textToInterpolate = this.getTextToInterpolate(key);
-    
+
       if (isDefinedAndNotNull(textToInterpolate))
       {
-        //Fast exit to avoid overhead if no params provided
-        if(isDefinedAndNotNull(interpolateParams))
           return this.runInterpolation(textToInterpolate, interpolateParams);
-        else
-          return textToInterpolate;
       }
 
       const res = this.missingTranslationHandler.handle({


### PR DESCRIPTION
The problem with this change is that it avoids running the translation through the TranslateParser.
This is indeed a performance improvement - but will break functionality.

1) The TranslateCompiler might return functions that have to be resolved - e.g. the message format compiler plugin relies on this
2) Users using the TranslateParser e.g. to resolve references to other translations or do other post-processing of the translations will also break.