### PR TITLE
fix(http-loader.spec): type instantiation is excessively deep and possibly infinite

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -19,8 +19,10 @@ export type Translation =
   string |
   Translation[] |
   TranslationObject |
-  undefined |
-  null
+
+  // required to prevent error "Type instantiation is excessively deep and possibly infinite."
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
   ;
 
 


### PR DESCRIPTION
## Description
Add `any` back to the `Translate` object as an overall rewritten of the interface & types have to be done before having the right to do so.