### PR TITLE
refactor(injectionToken): to TRANSLATE_CONFIG

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "karma-mocha-reporter": "^2.2.5",
         "ng-packagr": "^20.0.1",
-        "prettier": "3.6.2",        
+        "prettier": "3.6.2",
         "ts-mocks": "^3.0.1",
         "typescript": "~5.8.2",
         "typescript-eslint": "^8.18.1"

--- a/projects/ngx-translate/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/src/lib/translate.directive.ts
@@ -2,7 +2,8 @@ import {
     AfterViewChecked,
     ChangeDetectorRef,
     Directive,
-    ElementRef, inject,
+    ElementRef,
+    inject,
     Input,
     OnDestroy,
 } from "@angular/core";
@@ -32,10 +33,9 @@ interface ExtendedNode extends Text {
     standalone: true,
 })
 export class TranslateDirective implements AfterViewChecked, OnDestroy {
-
     private translateService: TranslateService = inject(TranslateService);
     private element: ElementRef = inject(ElementRef);
-    private _ref:ChangeDetectorRef = inject(ChangeDetectorRef);
+    private _ref: ChangeDetectorRef = inject(ChangeDetectorRef);
 
     private key!: string;
     private lastParams?: InterpolationParameters;
@@ -57,7 +57,6 @@ export class TranslateDirective implements AfterViewChecked, OnDestroy {
             this.checkNodes(true);
         }
     }
-
 
     constructor() {
         // subscribe to onTranslationChange event, in case the translations of the current lang change

--- a/projects/ngx-translate/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectorRef, inject, Injectable, OnDestroy, Pipe, PipeTransform } from "@angular/core";
+import {
+    ChangeDetectorRef,
+    inject,
+    Injectable,
+    OnDestroy,
+    Pipe,
+    PipeTransform,
+} from "@angular/core";
 import { isObservable, Subscription } from "rxjs";
 import {
     InterpolatableTranslationObject,
@@ -17,7 +24,6 @@ import { equals, isDefinedAndNotNull, isDict, isString } from "./util";
     pure: false, // required to update the value when the promise is resolved
 })
 export class TranslatePipe implements PipeTransform, OnDestroy {
-
     private translate: TranslateService = inject(TranslateService);
     private _ref: ChangeDetectorRef = inject(ChangeDetectorRef);
 
@@ -27,7 +33,6 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     onTranslationChange: Subscription | undefined;
     onLangChange: Subscription | undefined;
     onDefaultLangChange: Subscription | undefined;
-
 
     updateValue(
         key: string,

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -9,10 +9,10 @@ import { TranslateStore } from "./translate.store";
 import { insertValue, isArray, isDefinedAndNotNull, isDict, isString } from "./util";
 
 export const TRANSLATE_CONFIG = new InjectionToken<{
-  defaultLanguage?: Language;
-  extend: boolean;
-  isolate: boolean;
-  useDefaultLang: boolean;
+    defaultLanguage?: Language;
+    extend: boolean;
+    isolate: boolean;
+    useDefaultLang: boolean;
 }>("TRANSLATE_CONFIG");
 
 export type InterpolationParameters = Record<string, unknown>;
@@ -134,17 +134,17 @@ export class TranslateService {
     public currentLoader: TranslateLoader = inject(TranslateLoader);
     public compiler: TranslateCompiler = inject(TranslateCompiler);
     private parser: TranslateParser = inject(TranslateParser);
-    private missingTranslationHandler: MissingTranslationHandler = inject(MissingTranslationHandler);
+    private missingTranslationHandler: MissingTranslationHandler =
+        inject(MissingTranslationHandler);
 
-    private config = inject(TRANSLATE_CONFIG, {optional: true}) ?? {
-      defaultLanguage: undefined,
-      extend: false,
-      isolate: false,
-      useDefaultLang: true,
-    }
+    private config = inject(TRANSLATE_CONFIG, { optional: true }) ?? {
+        defaultLanguage: undefined,
+        extend: false,
+        isolate: false,
+        useDefaultLang: true,
+    };
 
-    constructor(
-    ) {
+    constructor() {
         if (this.config.isolate) {
             this.store = new TranslateStore();
         }
@@ -278,7 +278,11 @@ export class TranslateService {
     ): void {
         const interpolatableTranslations: InterpolatableTranslationObject =
             this.compiler.compileTranslations(translations, lang);
-        this.store.setTranslations(lang, interpolatableTranslations, shouldMerge || this.config.extend);
+        this.store.setTranslations(
+            lang,
+            interpolatableTranslations,
+            shouldMerge || this.config.extend,
+        );
     }
 
     public getLangs(): readonly Language[] {

--- a/projects/ngx-translate/src/public-api.ts
+++ b/projects/ngx-translate/src/public-api.ts
@@ -1,37 +1,35 @@
 import {
-    NgModule,
-    ModuleWithProviders,
-    Provider,
-    EnvironmentProviders,
-    makeEnvironmentProviders, Type,
+  EnvironmentProviders,
+  makeEnvironmentProviders,
+  ModuleWithProviders,
+  NgModule,
+  Provider,
+  Type,
 } from "@angular/core";
-import { TranslateLoader, TranslateFakeLoader } from "./lib/translate.loader";
 import {
-    MissingTranslationHandler,
-    FakeMissingTranslationHandler,
+  FakeMissingTranslationHandler,
+  MissingTranslationHandler,
 } from "./lib/missing-translation-handler";
-import { TranslateParser, TranslateDefaultParser } from "./lib/translate.parser";
 import { TranslateCompiler, TranslateFakeCompiler } from "./lib/translate.compiler";
 import { TranslateDirective } from "./lib/translate.directive";
+import { TranslateFakeLoader, TranslateLoader } from "./lib/translate.loader";
+import { TranslateDefaultParser, TranslateParser } from "./lib/translate.parser";
 import { TranslatePipe } from "./lib/translate.pipe";
-import { TranslateStore } from "./lib/translate.store";
 import {
-    USE_DEFAULT_LANG,
-    DEFAULT_LANGUAGE,
-    USE_EXTEND,
-    ISOLATE_TRANSLATE_SERVICE,
-    TranslateService,
+  TRANSLATE_CONFIG,
+  TranslateService,
 } from "./lib/translate.service";
+import { TranslateStore } from "./lib/translate.store";
 
-export * from "./lib/translate.loader";
-export * from "./lib/translate.service";
+export * from "./lib/extraction-marker";
 export * from "./lib/missing-translation-handler";
-export * from "./lib/translate.parser";
 export * from "./lib/translate.compiler";
 export * from "./lib/translate.directive";
+export * from "./lib/translate.loader";
+export * from "./lib/translate.parser";
 export * from "./lib/translate.pipe";
+export * from "./lib/translate.service";
 export * from "./lib/translate.store";
-export * from "./lib/extraction-marker";
 export * from "./lib/util";
 
 export interface TranslateModuleConfig
@@ -83,11 +81,13 @@ function providers(config: TranslateModuleConfig = {}, includeStore = true): Pro
         config.compiler || provideTranslateCompiler(TranslateFakeCompiler),
         config.parser || provideTranslateParser(TranslateDefaultParser),
         config.missingTranslationHandler || provideTranslateMissingTranslationHandler(FakeMissingTranslationHandler),
+        { provide: TRANSLATE_CONFIG, useValue: {
+          defaultLanguage: config.defaultLanguage,
+          extend: config.extend ?? false,
+          isolate: config.isolate ?? false,
+          useDefaultLang: config.useDefaultLang ?? true,
+        } },
         TranslateService,
-        { provide: ISOLATE_TRANSLATE_SERVICE, useValue: config.isolate },
-        { provide: USE_DEFAULT_LANG, useValue: config.useDefaultLang },
-        { provide: USE_EXTEND, useValue: config.extend },
-        { provide: DEFAULT_LANGUAGE, useValue: config.defaultLanguage },
     ];
 
     if(includeStore)

--- a/projects/ngx-translate/src/public-api.ts
+++ b/projects/ngx-translate/src/public-api.ts
@@ -1,24 +1,21 @@
 import {
-  EnvironmentProviders,
-  makeEnvironmentProviders,
-  ModuleWithProviders,
-  NgModule,
-  Provider,
-  Type,
+    EnvironmentProviders,
+    makeEnvironmentProviders,
+    ModuleWithProviders,
+    NgModule,
+    Provider,
+    Type,
 } from "@angular/core";
 import {
-  FakeMissingTranslationHandler,
-  MissingTranslationHandler,
+    FakeMissingTranslationHandler,
+    MissingTranslationHandler,
 } from "./lib/missing-translation-handler";
 import { TranslateCompiler, TranslateFakeCompiler } from "./lib/translate.compiler";
 import { TranslateDirective } from "./lib/translate.directive";
 import { TranslateFakeLoader, TranslateLoader } from "./lib/translate.loader";
 import { TranslateDefaultParser, TranslateParser } from "./lib/translate.parser";
 import { TranslatePipe } from "./lib/translate.pipe";
-import {
-  TRANSLATE_CONFIG,
-  TranslateService,
-} from "./lib/translate.service";
+import { TRANSLATE_CONFIG, TranslateService } from "./lib/translate.service";
 import { TranslateStore } from "./lib/translate.store";
 
 export * from "./lib/extraction-marker";
@@ -32,8 +29,7 @@ export * from "./lib/translate.service";
 export * from "./lib/translate.store";
 export * from "./lib/util";
 
-export interface TranslateModuleConfig
-{
+export interface TranslateModuleConfig {
     loader?: Provider;
     compiler?: Provider;
     parser?: Provider;
@@ -44,54 +40,50 @@ export interface TranslateModuleConfig
     extend?: boolean;
     useDefaultLang?: boolean;
     defaultLanguage?: string;
-};
+}
 
-export function provideTranslateLoader(loader: Type<TranslateLoader>): Provider
-{
+export function provideTranslateLoader(loader: Type<TranslateLoader>): Provider {
     return { provide: TranslateLoader, useClass: loader };
 }
 
-export function provideTranslateCompiler(compiler: Type<TranslateCompiler>): Provider
-{
+export function provideTranslateCompiler(compiler: Type<TranslateCompiler>): Provider {
     return { provide: TranslateCompiler, useClass: compiler };
 }
 
-export function provideTranslateParser(parser: Type<TranslateParser>): Provider
-{
+export function provideTranslateParser(parser: Type<TranslateParser>): Provider {
     return { provide: TranslateParser, useClass: parser };
 }
 
 export function provideTranslateMissingTranslationHandler(
     handler: Type<MissingTranslationHandler>,
-): Provider
-{
+): Provider {
     return { provide: MissingTranslationHandler, useClass: handler };
 }
 
-export function provideTranslateService(config: TranslateModuleConfig = {}): EnvironmentProviders
-{
+export function provideTranslateService(config: TranslateModuleConfig = {}): EnvironmentProviders {
     return makeEnvironmentProviders(providers(config));
 }
 
-
-function providers(config: TranslateModuleConfig = {}, includeStore = true): Provider[]
-{
+function providers(config: TranslateModuleConfig = {}, includeStore = true): Provider[] {
     const providers: Provider[] = [
         config.loader || provideTranslateLoader(TranslateFakeLoader),
         config.compiler || provideTranslateCompiler(TranslateFakeCompiler),
         config.parser || provideTranslateParser(TranslateDefaultParser),
-        config.missingTranslationHandler || provideTranslateMissingTranslationHandler(FakeMissingTranslationHandler),
-        { provide: TRANSLATE_CONFIG, useValue: {
-          defaultLanguage: config.defaultLanguage,
-          extend: config.extend ?? false,
-          isolate: config.isolate ?? false,
-          useDefaultLang: config.useDefaultLang ?? true,
-        } },
+        config.missingTranslationHandler ||
+            provideTranslateMissingTranslationHandler(FakeMissingTranslationHandler),
+        {
+            provide: TRANSLATE_CONFIG,
+            useValue: {
+                defaultLanguage: config.defaultLanguage,
+                extend: config.extend ?? false,
+                isolate: config.isolate ?? false,
+                useDefaultLang: config.useDefaultLang ?? true,
+            },
+        },
         TranslateService,
     ];
 
-    if(includeStore)
-    {
+    if (includeStore) {
         providers.push(TranslateStore);
     }
 

--- a/projects/ngx-translate/src/tests/translate.directive-module.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.directive-module.spec.ts
@@ -3,7 +3,7 @@ import {
     Component,
     ElementRef,
     Injectable,
-    ViewChild
+    ViewChild,
 } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { TranslateModule, TranslateService } from "../public-api";

--- a/projects/ngx-translate/src/tests/translate.pipe.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.pipe.spec.ts
@@ -15,9 +15,10 @@ describe("TranslatePipe (unit)", () => {
     let translatePipe: TranslatePipe;
 
     beforeEach(() => {
-
         ref = new Mock<ChangeDetectorRef>({
-            markForCheck: () => {/*empty*/},
+            markForCheck: () => {
+                /*empty*/
+            },
         }).Object;
 
         TestBed.configureTestingModule({
@@ -27,12 +28,12 @@ describe("TranslatePipe (unit)", () => {
                 }),
                 {
                     provide: ChangeDetectorRef,
-                    useValue: ref
+                    useValue: ref,
                 },
                 {
                     provide: TranslatePipe,
                     useClass: TranslatePipe,
-                }
+                },
             ],
         });
 

--- a/projects/ngx-translate/src/tests/translate.store.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.store.spec.ts
@@ -1,5 +1,11 @@
 import { Location } from "@angular/common";
-import { Component, inject as coreInject, ModuleWithProviders, NgModule, Type } from "@angular/core";
+import {
+    Component,
+    inject as coreInject,
+    ModuleWithProviders,
+    NgModule,
+    Type,
+} from "@angular/core";
 import { ComponentFixture, fakeAsync, TestBed, tick, inject } from "@angular/core/testing";
 import { provideRouter, Router, RouterModule } from "@angular/router";
 import { TranslateModule, TranslateService } from "../public-api";


### PR DESCRIPTION
## Description
Refactor the following 

```typescript
export const ISOLATE_TRANSLATE_SERVICE = new InjectionToken<string>("ISOLATE_TRANSLATE_SERVICE");
export const USE_DEFAULT_LANG = new InjectionToken<boolean>("USE_DEFAULT_LANG");
export const DEFAULT_LANGUAGE = new InjectionToken<Language>("DEFAULT_LANGUAGE");
export const USE_EXTEND = new InjectionToken<boolean>("USE_EXTEND");
```

Into one unique  injectionToken
```typescript
export const TRANSLATE_CONFIG = new InjectionToken<{
  defaultLanguage?: Language;
  extend: boolean;
  isolate: boolean;
  useDefaultLang: boolean;
}>("TRANSLATE_CONFIG");
```