### PR TITLE
refactor(service/instant): return type

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -30,7 +30,7 @@ export type InterpolationParameters = Record<string, any>;
 export type StrictTranslation = string | StrictTranslation[] | TranslationObject | undefined | null;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Translation = StrictTranslation | any;
+export type Translation<T = any> = StrictTranslation | T;
 
 export interface TranslationObject {
     [key: string]: StrictTranslation;
@@ -575,10 +575,11 @@ export class TranslateService implements ITranslateService {
      * All rules regarding the current language, the preferred language of even fallback languages
      * will be used except any promise handling.
      */
-    public instant(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public instant<T = any>(
         key: string | string[],
         interpolateParams?: InterpolationParameters,
-    ): Translation {
+    ): Translation<T> {
         if (!isDefinedAndNotNull(key) || key.length === 0) {
             throw new Error('Parameter "key" is required and cannot be empty');
         }

--- a/projects/test-app/src/app/app.component.ts
+++ b/projects/test-app/src/app/app.component.ts
@@ -38,7 +38,9 @@ export class AppComponent implements OnInit {
             .subscribe((result: string) => {
                 console.info(".get([])", result);
 
-                const instantTranslation = this._translate.instant("demo.simple.text-as-attribute");
+                const instantTranslation = this._translate.instant<string>(
+                    "demo.simple.text-as-attribute",
+                );
                 console.info("instant", instantTranslation);
             });
     }


### PR DESCRIPTION
## Description
As `any` cannot be avoided with the actual state of the library, I would propose a cleaner way to let people add types to the `instant()` method, as some people require they project to avoid using `any`. 

https://github.com/ngx-translate/core/issues/1534


## Note
I would prefer this approche over `as string`, as it would enable use to control the type directly inside the instant method, if we ever find the need to.